### PR TITLE
이슈 선점 조회 결과를 유저별로 그룹화하여 출력 (#228)

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -7,10 +7,10 @@ var app = CoconaApp.Create();
 app.AddCommand(async (
     [Argument] string repo,
     [Option('t', Description = "GitHub Personal Access Token")] string? token = null,
-    [Option("show-claims", Description = "최근 이슈 선점 현황 조회")] bool showClaims = false
+    [Option("show-claims", Description = "선점 현황 조회 (issue|user, 기본값: issue)")] string? showClaims = null
 ) =>
 {
-if (showClaims)
+if (showClaims != null)
 {
     if (string.IsNullOrEmpty(token))
         token = Environment.GetEnvironmentVariable("GITHUB_TOKEN");
@@ -23,7 +23,8 @@ if (showClaims)
 
     var parts = repo.Split('/');
     var service = new GitHubService(parts[0], parts[1], token);
-    await service.ShowRecentClaimsAsync();
+    var mode = string.IsNullOrEmpty(showClaims) ? "issue" : showClaims;
+    await service.ShowRecentClaimsAsync(mode);
     return;
 }
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ dotnet run -- oss2026hnu/reposcore-cs
 dotnet run -- oss2026hnu/reposcore-cs --token YOUR_GITHUB_TOKEN
 
 # 최근 이슈 선점 현황 조회 예시
-dotnet run -- oss2026hnu/reposcore-cs --show-claims
+dotnet run -- oss2026hnu/reposcore-cs --show-claims              # 이슈별 (기본값)
+dotnet run -- oss2026hnu/reposcore-cs --show-claims=issue        # 이슈별 (명시)
+dotnet run -- oss2026hnu/reposcore-cs --show-claims=user         # 유저별
 
 # 도움말 출력 (모든 인수 및 옵션 확인)
 dotnet run -- --help

--- a/Services/GitHubService.cs
+++ b/Services/GitHubService.cs
@@ -102,6 +102,8 @@ namespace RepoScore.Services
 
             Console.WriteLine("📌 최근 이슈 선점 현황\n");
 
+            var claimMap = new Dictionary<string, List<string>>();
+
             foreach (var issue in issues)
             {
                 foreach (var comment in issue.Comments)
@@ -112,12 +114,20 @@ namespace RepoScore.Services
                     if (s_claimKeywords.Any(k =>
                         comment.Body?.Contains(k, StringComparison.OrdinalIgnoreCase) == true))
                     {
-                        Console.WriteLine($"👤 {comment.Login}");
-                        Console.WriteLine($" - {issue.Url}");
-                        Console.WriteLine();
+                        if (!claimMap.ContainsKey(comment.Login))
+                            claimMap[comment.Login] = new List<string>();
+                        claimMap[comment.Login].Add(issue.Url);
                         break;
                     }
                 }
+            }
+
+            foreach (var (login, urls) in claimMap)
+            {
+                Console.WriteLine($"👤 {login}");
+                foreach (var url in urls)
+                    Console.WriteLine($" - {url}");
+                Console.WriteLine();
             }
         }
     }

--- a/Services/GitHubService.cs
+++ b/Services/GitHubService.cs
@@ -89,7 +89,7 @@ namespace RepoScore.Services
         }
 
         // 최근 이슈 선점 현황 조회
-        public async Task ShowRecentClaimsAsync()
+        public async Task ShowRecentClaimsAsync(string mode = "issue")
         {
             const string graphQL = @"
                 query($owner: String!, $name: String!) {
@@ -259,12 +259,42 @@ namespace RepoScore.Services
                         }
                     }
                 }
-                foreach (var (login, urls) in claimMap)
+                if (mode == "user")
                 {
-                    Console.WriteLine($"👤 {login}");
-                    foreach (var url in urls)
+                    foreach (var (login, urls) in claimMap)
+                    {
+                        Console.WriteLine($"👤 {login}");
+                        foreach (var url in urls)
+                            Console.WriteLine($" - {url}");
+                    }
+                }
+                else
+                {
+                    var claimedUrls = new HashSet<string>(
+                        claimMap.Values.SelectMany(urls => urls));
+
+                    var unclaimedIssues = new List<string>();
+                    foreach (var issue in nodes.EnumerateArray())
+                    {
+                        if (!issue.TryGetProperty("url", out var u) || u.ValueKind != JsonValueKind.String)
+                            continue;
+                        var url = u.GetString() ?? "";
+                        if (!claimedUrls.Contains(url))
+                            unclaimedIssues.Add(url);
+                    }
+
+                    Console.WriteLine("📋 미선점 이슈");
+                    foreach (var url in unclaimedIssues)
                         Console.WriteLine($" - {url}");
                     Console.WriteLine();
+
+                    Console.WriteLine("📌 선점된 이슈");
+                    foreach (var (login, urls) in claimMap)
+                    {
+                        Console.WriteLine($"👤 {login}");
+                        foreach (var url in urls)
+                            Console.WriteLine($" - {url}");
+                    }
                 }
             }
         }


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #228 

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- [x] ShowRecentClaimsAsync()의 출력을 유저별 그룹화로 변경

### 🧪 테스트 방법 (선택 사항)
<!-- 변경 사항이 정상 동작하는지 어떻게 확인했는지 작성해주세요 -->

`dotnet run -- oss2026hnu/reposcore-cs --show-claims -t YOUR_GITHUB_TOKEN` 으로 실행 시

변경전 출력
```
📌 최근 이슈 선점 현황

👤 HaGain-25
 - https://github.com/oss2026hnu/reposcore-cs/issues/247

👤 pangsu12
 - https://github.com/oss2026hnu/reposcore-cs/issues/246

👤 PlotSquared
 - https://github.com/oss2026hnu/reposcore-cs/issues/244

👤 roadingjoong
 - https://github.com/oss2026hnu/reposcore-cs/issues/237

👤 arror1784
 - https://github.com/oss2026hnu/reposcore-cs/issues/236

👤 Kkkjjhh
 - https://github.com/oss2026hnu/reposcore-cs/issues/231

👤 hngon
 - https://github.com/oss2026hnu/reposcore-cs/issues/230

👤 Kkkjjhh
 - https://github.com/oss2026hnu/reposcore-cs/issues/228

👤 hngon
 - https://github.com/oss2026hnu/reposcore-cs/issues/227

```

변경후 출력
```
📌 최근 이슈 선점 현황

👤 HaGain-25
 - https://github.com/oss2026hnu/reposcore-cs/issues/247

👤 pangsu12
 - https://github.com/oss2026hnu/reposcore-cs/issues/246

👤 PlotSquared
 - https://github.com/oss2026hnu/reposcore-cs/issues/244

👤 roadingjoong
 - https://github.com/oss2026hnu/reposcore-cs/issues/237

👤 arror1784
 - https://github.com/oss2026hnu/reposcore-cs/issues/236

👤 Kkkjjhh
 - https://github.com/oss2026hnu/reposcore-cs/issues/231
 - https://github.com/oss2026hnu/reposcore-cs/issues/228

👤 hngon
 - https://github.com/oss2026hnu/reposcore-cs/issues/230
 - https://github.com/oss2026hnu/reposcore-cs/issues/227

```
위와 같이 출력이 유저별로 이슈가 그룹화 되도록 변경함.

### 💬 참고 사항 (선택 사항)
<!-- 리뷰 시 참고해야 할 내용이나 전달하고 싶은 사항이 있다면 작성해주세요 -->

Dictionary<string, List<string>>를 사용하여 유저별로 이슈 URL을 수집한 뒤 출력함.