### PR TITLE
이슈 선점 현황에 남은 시간 및 PR 상태 표시 기능 추가

### DIFF
--- a/Services/GitHubService.cs
+++ b/Services/GitHubService.cs
@@ -26,6 +26,10 @@ namespace RepoScore.Services
         private static readonly string[] s_claimKeywords =
             ["제가 하겠습니다", "진행하겠습니다", "할게요", "I'll take this"];
 
+        // 작업 유형별 기한 (이슈 제목 키워드 기반 추론)
+        private static readonly string[] s_docKeywords =
+            ["doc", "docs", "문서", "readme", "guide", "typo", "오타"];
+
         static GitHubService()
         {
             s_httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("reposcore-cs");
@@ -88,6 +92,86 @@ namespace RepoScore.Services
             return new List<string>(result);
         }
 
+        // 이슈 번호로 연결된 오픈 PR 존재 여부 확인
+        private async Task<bool> HasLinkedPullRequestAsync(int issueNumber)
+        {
+            // GitHub REST API: 이슈에 연결된 타임라인 이벤트에서 cross-referenced PR 확인
+            // 또는 Search API로 해당 이슈를 닫는 PR 조회
+            var url = $"repos/{_owner}/{_repo}/issues/{issueNumber}/timeline";
+
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            request.Headers.Authorization =
+                new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _token);
+            // timeline API에는 preview 헤더 필요
+            request.Headers.Accept.ParseAdd("application/vnd.github.mockingbird-preview+json");
+
+            HttpResponseMessage response;
+            try
+            {
+                response = await s_httpClient.SendAsync(request);
+            }
+            catch
+            {
+                return false;
+            }
+
+            if (!response.IsSuccessStatusCode)
+                return false;
+
+            var body = await response.Content.ReadAsStringAsync();
+            JsonDocument document;
+            try
+            {
+                document = JsonDocument.Parse(body);
+            }
+            catch (JsonException)
+            {
+                return false;
+            }
+
+            using (document)
+            {
+                var root = document.RootElement;
+                if (root.ValueKind != JsonValueKind.Array)
+                    return false;
+
+                foreach (var evt in root.EnumerateArray())
+                {
+                    if (!evt.TryGetProperty("event", out var evtType))
+                        continue;
+
+                    // "cross-referenced" 이벤트 중 PR이 이슈를 closes 하는 경우
+                    if (evtType.GetString() == "cross-referenced"
+                        && evt.TryGetProperty("source", out var source)
+                        && source.TryGetProperty("type", out var sourceType)
+                        && sourceType.GetString() == "issue"
+                        && source.TryGetProperty("issue", out var linkedIssue)
+                        && linkedIssue.TryGetProperty("pull_request", out _))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        // 이슈 제목으로 문서/오타 작업인지 추론 (기한 결정용)
+        private static bool IsDocumentTask(string issueTitle)
+        {
+            var lower = issueTitle.ToLowerInvariant();
+            return s_docKeywords.Any(k => lower.Contains(k));
+        }
+
+        // 남은 시간 문자열 생성
+        private static string FormatRemainingTime(TimeSpan remaining)
+        {
+            if (remaining <= TimeSpan.Zero)
+                return "⌛ 기한 초과";
+
+            return $"⏳ 남은 시간: {(int)remaining.TotalHours:D2}:{remaining.Minutes:D2}:{remaining.Seconds:D2}";
+        }
+
         // 최근 이슈 선점 현황 조회
         public async Task ShowRecentClaimsAsync()
         {
@@ -96,6 +180,8 @@ namespace RepoScore.Services
                   repository(owner: $owner, name: $name) {
                     issues(first: 20, states: OPEN, orderBy: { field: CREATED_AT, direction: DESC }) {
                       nodes {
+                        number
+                        title
                         url
                         comments(first: 10) {
                           nodes {
@@ -212,12 +298,24 @@ namespace RepoScore.Services
                 var now = DateTimeOffset.UtcNow;
                 Console.WriteLine("📌 최근 이슈 선점 현황\n");
 
+                bool foundAny = false;
+
                 foreach (var issue in nodes.EnumerateArray())
                 {
                     if (!issue.TryGetProperty("url", out var urlProperty) || urlProperty.ValueKind != JsonValueKind.String)
                         continue;
 
                     var issueUrl = urlProperty.GetString() ?? string.Empty;
+
+                    // 이슈 번호 및 제목 추출
+                    var issueNumber = issue.TryGetProperty("number", out var numProp)
+                        ? numProp.GetInt32()
+                        : 0;
+
+                    var issueTitle = issue.TryGetProperty("title", out var titleProp)
+                        && titleProp.ValueKind == JsonValueKind.String
+                        ? titleProp.GetString() ?? string.Empty
+                        : string.Empty;
 
                     if (!issue.TryGetProperty("comments", out var comments) || comments.ValueKind != JsonValueKind.Object)
                         continue;
@@ -235,10 +333,10 @@ namespace RepoScore.Services
                         if (!comment.TryGetProperty("createdAt", out var createdAtProperty) || createdAtProperty.ValueKind != JsonValueKind.String)
                             continue;
 
-                        if (!DateTimeOffset.TryParse(createdAtProperty.GetString(), out var createdAt))
+                        if (!DateTimeOffset.TryParse(createdAtProperty.GetString(), out var claimedAt))
                             continue;
 
-                        if ((now - createdAt).TotalHours > 48)
+                        if ((now - claimedAt).TotalHours > 48)
                             continue;
 
                         if (!comment.TryGetProperty("author", out var author) || author.ValueKind != JsonValueKind.Object)
@@ -248,14 +346,41 @@ namespace RepoScore.Services
                             ? loginProperty.GetString()
                             : "unknown";
 
-                        if (s_claimKeywords.Any(k => commentBody.Contains(k, StringComparison.OrdinalIgnoreCase)))
+                        if (!s_claimKeywords.Any(k => commentBody.Contains(k, StringComparison.OrdinalIgnoreCase)))
+                            continue;
+
+                        foundAny = true;
+
+                        // 작업 유형에 따른 기한 결정
+                        bool isDoc = IsDocumentTask(issueTitle);
+                        double deadlineHours = isDoc ? 24.0 : 48.0;
+                        var deadline = claimedAt.AddHours(deadlineHours);
+                        var remaining = deadline - now;
+
+                        // PR 연결 여부 확인
+                        bool hasPr = issueNumber > 0 && await HasLinkedPullRequestAsync(issueNumber);
+
+                        // 출력
+                        Console.WriteLine($"👤 {login}");
+                        Console.WriteLine($" - {issueUrl}");
+
+                        if (hasPr)
                         {
-                            Console.WriteLine($"👤 {login}");
-                            Console.WriteLine($" - {issueUrl}");
-                            Console.WriteLine();
-                            break;
+                            Console.WriteLine($" - ✅ PR 생성됨");
                         }
+                        else
+                        {
+                            Console.WriteLine($" - {FormatRemainingTime(remaining)}");
+                        }
+
+                        Console.WriteLine();
+                        break;
                     }
+                }
+
+                if (!foundAny)
+                {
+                    Console.WriteLine("최근 48시간 내 선점된 이슈가 없습니다.");
                 }
             }
         }


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #244 

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- [x] GraphQL 쿼리에 `number`, `title` 필드 추가 (이슈 번호·제목 수신)
- [x] 선점 댓글 시각 기준 남은 시간 계산 및 표시 (`⏳ 남은 시간: HH:MM:SS`)
- [x] 이슈 제목 키워드로 작업 유형 추론 (문서 24h / 코드 48h)
- [x] GitHub Timeline API로 연결된 PR 존재 여부 확인
- [x] PR 생성 시 시간 표시 대신 `✅ PR 생성됨` 출력

### 🧪 테스트 방법
```bash
dotnet run -- oss2026hnu/reposcore-cs --show-claims --token $GITHUB_TOKEN
```
선점 댓글이 있는 이슈에서 아래 두 가지 상태를 확인합니다.
- PR 없음 → `⏳ 남은 시간: 01:23:45`
- PR 있음 → `✅ PR 생성됨`
### 💬 참고 사항 (선택 사항)
<!-- 리뷰 시 참고해야 할 내용이나 전달하고 싶은 사항이 있다면 작성해주세요 -->
