### PR TITLE
선점된 이슈 정보 표시할 때 mode가 user일때 미선점 이슈 표기 추가

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -107,6 +107,10 @@ static void PrintClaimsReport(ClaimsData data, string mode)
 
     if (mode == "user")
     {
+        Console.WriteLine("📋 미선점 이슈");
+        foreach (var url in data.UnclaimedUrls) Console.WriteLine($" - {url}");
+        Console.WriteLine("\n📌 선점된 이슈");
+
         foreach (var (login, claims) in data.ClaimedMap)
         {
             Console.WriteLine($"👤 {login}");


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #268 

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- [ ]  --show-claims=user에서 미선점 이슈 표시 추가

### 🧪 테스트 방법 (선택 사항)
dotnet run -- oss2026hnu/reposcore-cs --token {토큰} --show-claims=user

위 명령어를 실행하여 미선점 이슈 표시 확인

### 💬 참고 사항 (선택 사항)

