### PR TITLE
GetClaims 메서드 오류 개선 #291

### DIFF
--- a/Services/GitHubService.cs
+++ b/Services/GitHubService.cs
@@ -1,11 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
-using System.Text;
 using System.Text.Json;
-using System.Threading.Tasks;
-using Octokit; 
+using Octokit;
 using Octokit.GraphQL;
 using Octokit.GraphQL.Model;
 
@@ -64,8 +61,6 @@ namespace RepoScore.Services
         private readonly Octokit.GitHubClient _restClient;
         private readonly string _owner;
         private readonly string _repo;
-        private readonly string _token;
-        private static readonly HttpClient s_httpClient = new HttpClient();
 
         private static readonly string[] s_claimKeywords = ["제가 하겠습니다", "진행하겠습니다", "할게요", "I'll take this"];
 
@@ -73,7 +68,6 @@ namespace RepoScore.Services
         {
             _owner = owner;
             _repo = repo;
-            _token = token;
             if (string.IsNullOrEmpty(token)) throw new ArgumentNullException(nameof(token));
 
             // 1. GraphQL 커넥션 초기화
@@ -122,155 +116,83 @@ namespace RepoScore.Services
 
         public List<ClaimRecord> GetClaims(string authorLogin)
         {
-            // HttpClient와 JsonDocument를 사용하여 직접 GraphQL API 호출
-            const string graphQLQuery = @"
-                query($search: String!) {
-                  search(query: $search, type: ISSUE, first: 50) {
+            const string rawGraphQl = @"
+            query($searchQuery: String!) {
+                search(query: $searchQuery, type: ISSUE, first: 50) {
                     nodes {
-                      ... on Issue {
-                        number
-                        title
-                        url
-                        stateReason
-                        labels(first: 10) {
-                          nodes {
-                            name
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-            ";
-
-            var requestBody = new
-            {
-                query = graphQLQuery,
-                variables = new { search = $"repo:{_owner}/{_repo} is:issue author:{authorLogin}" }
-            };
-
-            var claimRecords = new List<ClaimRecord>();
-
-            try
-            {
-                var jsonContent = new StringContent(
-                    JsonSerializer.Serialize(requestBody),
-                    Encoding.UTF8,
-                    "application/json");
-
-                var request = new HttpRequestMessage(HttpMethod.Post, "https://api.github.com/graphql")
-                {
-                    Content = jsonContent
-                };
-                request.Headers.Authorization = 
-                    new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _token);
-                request.Headers.Add("User-Agent", "reposcore-cs");
-
-                var response = s_httpClient.SendAsync(request).Result;
-
-                if (!response.IsSuccessStatusCode)
-                {
-                    Console.WriteLine($"GitHub API 요청 실패: HTTP {(int)response.StatusCode}");
-                    return claimRecords;
-                }
-
-                var body = response.Content.ReadAsStringAsync().Result;
-                using var document = JsonDocument.Parse(body);
-                var root = document.RootElement;
-
-                // 에러 확인
-                if (root.TryGetProperty("errors", out var errors) && errors.ValueKind == JsonValueKind.Array)
-                {
-                    if (errors.GetArrayLength() > 0)
-                    {
-                        Console.WriteLine("GraphQL 오류가 발생했습니다:");
-                        foreach (var error in errors.EnumerateArray())
-                        {
-                            if (error.TryGetProperty("message", out var errorMessage))
-                            {
-                                Console.WriteLine($" - {errorMessage.GetString()}");
-                            }
-                        }
-                        return claimRecords;
-                    }
-                }
-
-                // 데이터 추출
-                if (!root.TryGetProperty("data", out var data) ||
-                    !data.TryGetProperty("search", out var search) ||
-                    !search.TryGetProperty("nodes", out var nodes))
-                {
-                    return claimRecords;
-                }
-
-                foreach (var issue in nodes.EnumerateArray())
-                {
-                    var claimClosedReason = IssueClosedStateReason.None;
-
-                    // stateReason을 문자열로 직접 처리 (DUPLICATE 포함 모든 값 수용)
-                    if (issue.TryGetProperty("stateReason", out var stateReasonProp) && 
-                        stateReasonProp.ValueKind == JsonValueKind.String)
-                    {
-                        var reasonStr = stateReasonProp.GetString()?.ToUpperInvariant() ?? "";
-                        claimClosedReason = reasonStr switch
-                        {
-                            "COMPLETED" => IssueClosedStateReason.Completed,
-                            "DUPLICATE" => IssueClosedStateReason.Duplicate,
-                            "NOTPLANNED" or "NOT_PLANNED" => IssueClosedStateReason.NotPlanned,
-                            _ => IssueClosedStateReason.None
-                        };
-                    }
-
-                    // 라벨 추출
-                    var labels = new List<GitHubIssuePrLabel>();
-                    if (issue.TryGetProperty("labels", out var labelsObj) &&
-                        labelsObj.TryGetProperty("nodes", out var labelNodes))
-                    {
-                        foreach (var label in labelNodes.EnumerateArray())
-                        {
-                            if (label.TryGetProperty("name", out var labelName))
-                            {
-                                var parsedLabel = ParseGitHubLabel(labelName.GetString() ?? "");
-                                if (parsedLabel != GitHubIssuePrLabel.None)
-                                {
-                                    labels.Add(parsedLabel);
+                        ... on Issue {
+                            number
+                            title
+                            url
+                            stateReason
+                            labels(first: 10) {
+                                nodes {
+                                    name
                                 }
                             }
                         }
                     }
-
-                    var number = 0;
-                    var title = string.Empty;
-                    var url = string.Empty;
-
-                    if (issue.TryGetProperty("number", out var numberProp) && numberProp.ValueKind == JsonValueKind.Number)
-                    {
-                        number = numberProp.GetInt32();
-                    }
-
-                    if (issue.TryGetProperty("title", out var titleProp) && titleProp.ValueKind == JsonValueKind.String)
-                    {
-                        title = titleProp.GetString() ?? "";
-                    }
-
-                    if (issue.TryGetProperty("url", out var urlProp) && urlProp.ValueKind == JsonValueKind.String)
-                    {
-                        url = urlProp.GetString() ?? "";
-                    }
-
-                    claimRecords.Add(new ClaimRecord
-                    {
-                        Number = number,
-                        Title = title,
-                        Url = url,
-                        ClosedReason = claimClosedReason,
-                        Labels = labels
-                    });
                 }
-            }
-            catch (Exception ex)
+            }";
+
+            var requestPayload = BuildRawQueryPayload(
+                rawGraphQl,
+                new Dictionary<string, object>
+                {
+                    ["searchQuery"] = $"repo:{_owner}/{_repo} is:issue author:{authorLogin}"
+                });
+
+            var rawResponse = _graphQLConnection.Run(requestPayload).Result;
+            var claimRecords = new List<ClaimRecord>();
+
+            using var document = JsonDocument.Parse(rawResponse);
+
+            if (!document.RootElement.TryGetProperty("data", out var dataElement) ||
+                !dataElement.TryGetProperty("search", out var searchElement) ||
+                !searchElement.TryGetProperty("nodes", out var nodesElement) ||
+                nodesElement.ValueKind != JsonValueKind.Array)
             {
-                Console.WriteLine($"GetClaims 메서드 실행 중 오류 발생: {ex.Message}");
+                return claimRecords;
+            }
+
+            foreach (var node in nodesElement.EnumerateArray())
+            {
+                if (node.ValueKind != JsonValueKind.Object)
+                    continue;
+
+                var labelNames = new List<string>();
+                if (node.TryGetProperty("labels", out var labelsElement) &&
+                    labelsElement.ValueKind == JsonValueKind.Object &&
+                    labelsElement.TryGetProperty("nodes", out var labelNodesElement) &&
+                    labelNodesElement.ValueKind == JsonValueKind.Array)
+                {
+                    foreach (var labelNode in labelNodesElement.EnumerateArray())
+                    {
+                        if (labelNode.ValueKind == JsonValueKind.Object &&
+                            labelNode.TryGetProperty("name", out var labelNameElement) &&
+                            labelNameElement.ValueKind == JsonValueKind.String)
+                        {
+                            var labelName = labelNameElement.GetString();
+                            if (!string.IsNullOrWhiteSpace(labelName))
+                                labelNames.Add(labelName);
+                        }
+                    }
+                }
+
+                claimRecords.Add(new ClaimRecord
+                {
+                    Number = node.TryGetProperty("number", out var numberElement) && numberElement.TryGetInt32(out var number)
+                        ? number
+                        : 0,
+                    Title = node.TryGetProperty("title", out var titleElement) && titleElement.ValueKind == JsonValueKind.String
+                        ? titleElement.GetString() ?? string.Empty
+                        : string.Empty,
+                    Url = node.TryGetProperty("url", out var urlElement) && urlElement.ValueKind == JsonValueKind.String
+                        ? urlElement.GetString() ?? string.Empty
+                        : string.Empty,
+                    ClosedReason = ParseIssueClosedStateReason(node),
+                    Labels = labelNames.Select(ParseGitHubLabel).Where(l => l != GitHubIssuePrLabel.None).ToList()
+                });
             }
 
             return claimRecords;
@@ -333,6 +255,33 @@ namespace RepoScore.Services
                 "typo" => GitHubIssuePrLabel.Typo,
                 "wontfix" => GitHubIssuePrLabel.Wontfix,
                 _ => GitHubIssuePrLabel.None,
+            };
+        }
+
+        private static string BuildRawQueryPayload(string query, Dictionary<string, object> variables)
+        {
+            return JsonSerializer.Serialize(new
+            {
+                query,
+                variables
+            });
+        }
+
+        private static IssueClosedStateReason ParseIssueClosedStateReason(JsonElement issueNode)
+        {
+            if (!issueNode.TryGetProperty("stateReason", out var stateReasonElement) ||
+                stateReasonElement.ValueKind == JsonValueKind.Null)
+            {
+                return IssueClosedStateReason.None;
+            }
+
+            var reason = stateReasonElement.GetString()?.ToUpperInvariant();
+            return reason switch
+            {
+                "COMPLETED" => IssueClosedStateReason.Completed,
+                "DUPLICATE" => IssueClosedStateReason.Duplicate,
+                "NOT_PLANNED" or "NOTPLANNED" => IssueClosedStateReason.NotPlanned,
+                _ => IssueClosedStateReason.None
             };
         }
 

--- a/Services/GitHubService.cs
+++ b/Services/GitHubService.cs
@@ -1,6 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
 using Octokit; 
 using Octokit.GraphQL;
 using Octokit.GraphQL.Model;
@@ -60,6 +64,8 @@ namespace RepoScore.Services
         private readonly Octokit.GitHubClient _restClient;
         private readonly string _owner;
         private readonly string _repo;
+        private readonly string _token;
+        private static readonly HttpClient s_httpClient = new HttpClient();
 
         private static readonly string[] s_claimKeywords = ["제가 하겠습니다", "진행하겠습니다", "할게요", "I'll take this"];
 
@@ -67,6 +73,7 @@ namespace RepoScore.Services
         {
             _owner = owner;
             _repo = repo;
+            _token = token;
             if (string.IsNullOrEmpty(token)) throw new ArgumentNullException(nameof(token));
 
             // 1. GraphQL 커넥션 초기화
@@ -115,47 +122,155 @@ namespace RepoScore.Services
 
         public List<ClaimRecord> GetClaims(string authorLogin)
         {
-            var query = new Octokit.GraphQL.Query()
-                .Search(query: $"repo:{_owner}/{_repo} is:issue author:{authorLogin}", type: SearchType.Issue, first: 50)
-                .Nodes
-                .OfType<Octokit.GraphQL.Model.Issue>()
-                .Select(issue => new
-                {
-                    issue.Number,
-                    issue.Title,
-                    issue.Url,
-                    issue.StateReason, // main 브랜치의 closedReason 요구사항 통합
-                    Labels = issue.Labels(10, null, null, null, null).Nodes.Select(l => l.Name).ToList()
-                });
+            // HttpClient와 JsonDocument를 사용하여 직접 GraphQL API 호출
+            const string graphQLQuery = @"
+                query($search: String!) {
+                  search(query: $search, type: ISSUE, first: 50) {
+                    nodes {
+                      ... on Issue {
+                        number
+                        title
+                        url
+                        stateReason
+                        labels(first: 10) {
+                          nodes {
+                            name
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+            ";
 
-            var result = _graphQLConnection.Run(query).Result;
+            var requestBody = new
+            {
+                query = graphQLQuery,
+                variables = new { search = $"repo:{_owner}/{_repo} is:issue author:{authorLogin}" }
+            };
+
             var claimRecords = new List<ClaimRecord>();
 
-            foreach (var issue in result)
+            try
             {
-                var claimClosedReason = IssueClosedStateReason.None;
-                
-                // GraphQL 열거형 데이터를 내부 열거형 모델로 매핑
-                if (issue.StateReason.HasValue)
+                var jsonContent = new StringContent(
+                    JsonSerializer.Serialize(requestBody),
+                    Encoding.UTF8,
+                    "application/json");
+
+                var request = new HttpRequestMessage(HttpMethod.Post, "https://api.github.com/graphql")
                 {
-                    var reasonStr = issue.StateReason.Value.ToString().ToUpperInvariant();
-                    claimClosedReason = reasonStr switch
-                    {
-                        "COMPLETED" => IssueClosedStateReason.Completed,
-                        "DUPLICATE" => IssueClosedStateReason.Duplicate,
-                        "NOTPLANNED" or "NOT_PLANNED" => IssueClosedStateReason.NotPlanned,
-                        _ => IssueClosedStateReason.None
-                    };
+                    Content = jsonContent
+                };
+                request.Headers.Authorization = 
+                    new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _token);
+                request.Headers.Add("User-Agent", "reposcore-cs");
+
+                var response = s_httpClient.SendAsync(request).Result;
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    Console.WriteLine($"GitHub API 요청 실패: HTTP {(int)response.StatusCode}");
+                    return claimRecords;
                 }
 
-                claimRecords.Add(new ClaimRecord
+                var body = response.Content.ReadAsStringAsync().Result;
+                using var document = JsonDocument.Parse(body);
+                var root = document.RootElement;
+
+                // 에러 확인
+                if (root.TryGetProperty("errors", out var errors) && errors.ValueKind == JsonValueKind.Array)
                 {
-                    Number = issue.Number,
-                    Title = issue.Title,
-                    Url = issue.Url,
-                    ClosedReason = claimClosedReason,
-                    Labels = issue.Labels.Select(ParseGitHubLabel).Where(l => l != GitHubIssuePrLabel.None).ToList()
-                });
+                    if (errors.GetArrayLength() > 0)
+                    {
+                        Console.WriteLine("GraphQL 오류가 발생했습니다:");
+                        foreach (var error in errors.EnumerateArray())
+                        {
+                            if (error.TryGetProperty("message", out var errorMessage))
+                            {
+                                Console.WriteLine($" - {errorMessage.GetString()}");
+                            }
+                        }
+                        return claimRecords;
+                    }
+                }
+
+                // 데이터 추출
+                if (!root.TryGetProperty("data", out var data) ||
+                    !data.TryGetProperty("search", out var search) ||
+                    !search.TryGetProperty("nodes", out var nodes))
+                {
+                    return claimRecords;
+                }
+
+                foreach (var issue in nodes.EnumerateArray())
+                {
+                    var claimClosedReason = IssueClosedStateReason.None;
+
+                    // stateReason을 문자열로 직접 처리 (DUPLICATE 포함 모든 값 수용)
+                    if (issue.TryGetProperty("stateReason", out var stateReasonProp) && 
+                        stateReasonProp.ValueKind == JsonValueKind.String)
+                    {
+                        var reasonStr = stateReasonProp.GetString()?.ToUpperInvariant() ?? "";
+                        claimClosedReason = reasonStr switch
+                        {
+                            "COMPLETED" => IssueClosedStateReason.Completed,
+                            "DUPLICATE" => IssueClosedStateReason.Duplicate,
+                            "NOTPLANNED" or "NOT_PLANNED" => IssueClosedStateReason.NotPlanned,
+                            _ => IssueClosedStateReason.None
+                        };
+                    }
+
+                    // 라벨 추출
+                    var labels = new List<GitHubIssuePrLabel>();
+                    if (issue.TryGetProperty("labels", out var labelsObj) &&
+                        labelsObj.TryGetProperty("nodes", out var labelNodes))
+                    {
+                        foreach (var label in labelNodes.EnumerateArray())
+                        {
+                            if (label.TryGetProperty("name", out var labelName))
+                            {
+                                var parsedLabel = ParseGitHubLabel(labelName.GetString() ?? "");
+                                if (parsedLabel != GitHubIssuePrLabel.None)
+                                {
+                                    labels.Add(parsedLabel);
+                                }
+                            }
+                        }
+                    }
+
+                    var number = 0;
+                    var title = string.Empty;
+                    var url = string.Empty;
+
+                    if (issue.TryGetProperty("number", out var numberProp) && numberProp.ValueKind == JsonValueKind.Number)
+                    {
+                        number = numberProp.GetInt32();
+                    }
+
+                    if (issue.TryGetProperty("title", out var titleProp) && titleProp.ValueKind == JsonValueKind.String)
+                    {
+                        title = titleProp.GetString() ?? "";
+                    }
+
+                    if (issue.TryGetProperty("url", out var urlProp) && urlProp.ValueKind == JsonValueKind.String)
+                    {
+                        url = urlProp.GetString() ?? "";
+                    }
+
+                    claimRecords.Add(new ClaimRecord
+                    {
+                        Number = number,
+                        Title = title,
+                        Url = url,
+                        ClosedReason = claimClosedReason,
+                        Labels = labels
+                    });
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"GetClaims 메서드 실행 중 오류 발생: {ex.Message}");
             }
 
             return claimRecords;


### PR DESCRIPTION
### ISSUE_ID
Closes  https://github.com/oss2026hnu/reposcore-cs/issues/291

### 변경사항
- [x] `GetClaims` 메서드에서 `issue.StateReason`의 강타입 Enum 매핑을 제거하고 raw GraphQL 응답을 직접 파싱하도록 수정
- [x] GitHub API가 반환하는 `DUPLICATE` 값을 처리할 수 있도록 `JsonDocument` 기반의 `stateReason` 문자열 파싱 로직 추가
- [x] raw GraphQL 요청 생성 및 닫힘 사유 변환을 위한 새로운 메서드(`BuildRawQueryPayload`, `ParseIssueClosedStateReason`) 추가

### 🧪 테스트 방법 (선택 사항)

### 💬 참고 사항 (선택 사항)
요청 payload 생성과 `stateReason` 값 변환 로직을 분리하기 위해 아래 새로운 메서드를 추가했습니다.
- `BuildRawQueryPayload`: raw GraphQL 요청 본문 생성
- `ParseIssueClosedStateReason`: `stateReason` 문자열 값을 내부 Enum(`IssueClosedStateReason`)으로 안전하게 변환