### PR TITLE
생성자 중복 제거 및 통합

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -16,7 +16,8 @@ app.AddCommand((
     [Option('f', Description = "출력 형식 (csv, txt)")] string format = "csv",
     [Option('o', Description = "출력 디렉토리 경로")] string output = "./results",
     [Option(Description = "정렬 기준 (score | id)")] string sortBy = "score",
-    [Option(Description = "정렬 방법 (asc | desc)")] string sortOrder = "desc"
+    [Option(Description = "정렬 방법 (asc | desc)")] string sortOrder = "desc",
+    [Option(Description = "이슈 선점 키워드 (쉼표 구분, 미입력시 기본값 사용)")] string? keywords = null
 ) =>
 {
     // 1. 토큰 및 저장소 검증
@@ -28,7 +29,12 @@ app.AddCommand((
 
     string ownerName = parts[0];
     string repoName = parts[1];
-    var service = new GitHubService(ownerName, repoName, token);
+
+    string[]? parsedKeywords = keywords != null
+        ? keywords.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+        : null;
+
+    var service = new GitHubService(ownerName, repoName, token, parsedKeywords);
 
     try
     {
@@ -177,7 +183,6 @@ static string BuildTextReport(
 }
 
 // 이슈 선점 현황 리포트를 문자열로 생성하는 메서드
-// 콘솔 출력과 파일 저장 모두 이 메서드를 통해 동일한 내용을 사용합니다.
 static string BuildClaimsReport(ClaimsData data, string mode)
 {
     var sb = new StringBuilder();

--- a/Services/GitHubService.cs
+++ b/Services/GitHubService.cs
@@ -62,13 +62,16 @@ namespace RepoScore.Services
         private readonly string _owner;
         private readonly string _repo;
 
-        private static readonly string[] s_claimKeywords = ["제가 하겠습니다", "진행하겠습니다", "할게요", "I'll take this"];
+        private static readonly string[] s_defaultClaimKeywords = ["제가 하겠습니다", "진행하겠습니다", "할게요", "I'll take this"];
+        private readonly string[] _claimKeywords;
 
-        public GitHubService(string owner, string repo, string token)
+        public GitHubService(string owner, string repo, string token, string[]? keywords = null)
         {
             _owner = owner;
             _repo = repo;
             if (string.IsNullOrEmpty(token)) throw new ArgumentNullException(nameof(token));
+
+            _claimKeywords = keywords ?? s_defaultClaimKeywords;
 
             // 1. GraphQL 커넥션 초기화
             _graphQLConnection = new Octokit.GraphQL.Connection(
@@ -92,7 +95,7 @@ namespace RepoScore.Services
                     pr.Number,
                     pr.Title,
                     pr.Url,
-                    pr.Merged, // main 브랜치의 IsMerged 요구사항 통합
+                    pr.Merged,
                     Labels = pr.Labels(10, null, null, null, null).Nodes.Select(l => l.Name).ToList()
                 });
 
@@ -318,7 +321,7 @@ namespace RepoScore.Services
 
                     var login = comment.AuthorLogin ?? "unknown";
 
-                    if (s_claimKeywords.Any(k => comment.Body.Contains(k, StringComparison.OrdinalIgnoreCase)))
+                    if (_claimKeywords.Any(k => comment.Body.Contains(k, StringComparison.OrdinalIgnoreCase)))
                     {
                         var deadlineHours = IsDocumentTask(issueLabels) ? 24.0 : 48.0;
                         var remaining = comment.CreatedAt.AddHours(deadlineHours) - now;


### PR DESCRIPTION
### ISSUE_ID
Closes #276 

### 변경사항
- [x] `GitHubService` 중복 생성자를 `keywords = null` 디폴트 인수로 단일 생성자로 통합
- [x] `s_claimKeywords` static 필드를 `s_defaultClaimKeywords`(기본값)와 `_claimKeywords`(인스턴스)로 분리
- [x] `Program.cs`에 `--keywords` 옵션 추가 및 `GitHubService` 생성 시 파싱된 키워드 전달

### 🧪 테스트 방법
# 기본값 사용 (키워드 미입력)
dotnet run -- oss2026hnu/reposcore-cs --claims --token YOUR_TOKEN

# 커스텀 키워드 지정
dotnet run -- oss2026hnu/reposcore-cs --claims --token YOUR_TOKEN --keywords "제가 하겠습니다,할게요"
