### PR TITLE
Cocona minimal API 스타일로 변경

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -7,9 +7,7 @@ using Cocona;
 using RepoScore.Data;
 using RepoScore.Services;
 
-var app = CoconaApp.Create();
-
-app.AddCommand((
+CoconaApp.Run((
     [Argument(Description = "대상 저장소 (예: owner/repo)")] string repo,
     [Option('t', Description = "GitHub Token (미입력시 GITHUB_TOKEN 사용)")] string? token = null,
     [Option(Description = "최근 이슈 선점 현황 조회 (issue|user)")] string? claims = null,
@@ -141,8 +139,6 @@ app.AddCommand((
         Console.Error.WriteLine($"데이터 처리 중 오류 발생: {ex.Message}");
     }
 });
-
-app.Run();
 
 static List<(string Id, int docIssues, int featBugIssues, int typoPrs, int docPrs, int featBugPrs, int Score)>
 SortReportData(List<(string Id, int docIssues, int featBugIssues, int typoPrs, int docPrs, int featBugPrs, int Score)> data,


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #302 

변경사항

 [] CoconaApp.Create() + app.AddCommand() + app.Run() 3단계 호출 제거
 [] CoconaApp.Run(lambda) 단일 호출 구조로 통합

🧪 테스트 방법
bashdotnet run -- oss2026hnu/reposcore-cs --token $GITHUB_TOKEN
dotnet run -- --help
동작 결과 기존과 동일한지 확인.

💬 참고 사항
로직 변경 없음. Program.cs 진입부 구조만 단순화. Cocona 단일 커맨드 권장 패턴 적용.