### PR TITLE
fix: --format 옵션 유효성 검증 추가 (#315)

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -27,6 +27,13 @@ CoconaApp.Run((
     string ownerName = parts[0];
     string repoName = parts[1];
 
+    var allowedFormats = new[] { "csv", "txt" };
+    if (!allowedFormats.Contains(format.ToLowerInvariant()))
+    {
+        Console.Error.WriteLine($"오류: 지원하지 않는 형식입니다. csv 또는 txt를 입력해 주세요. (입력값: {format})");
+        return;
+    }
+
     string[]? parsedKeywords = keywords != null
         ? keywords.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
         : null;


### PR DESCRIPTION
### ISSUE_ID
Closes #315

### 변경사항
- [x] `--format` 옵션에 csv/txt 외 값 입력 시 오류 메시지 출력 후 종료하도록 검증 추가

### 🧪 테스트 방법
- `dotnet run -- oss2026hnu/reposcore-cs -f json --token $GITHUB_TOKEN` → 오류 메시지 출력 후 종료 확인
- `dotnet run -- oss2026hnu/reposcore-cs -f csv --token $GITHUB_TOKEN` → 정상 동작 확인
- `dotnet run -- oss2026hnu/reposcore-cs -f txt --token $GITHUB_TOKEN` → 정상 동작 확인

### 💬 참고 사항
이슈 #315 해결을 위한 --format 입력값에 대한 검증 코드를 추가하였습니다.