### PR TITLE
fix: BuildClaimsReport mode 분기 구현 및 Repository 파라미터 순서 수정

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -211,26 +211,80 @@ static string BuildClaimsReport(ClaimsData data, string mode)
 {
     var sb = new StringBuilder();
 
-    if (data.ClaimedMap.Count == 0)
+    if (data.ClaimedMap.Count == 0 && data.UnclaimedUrls.Count == 0)
     {
         sb.AppendLine("최근 48시간 내 선점된 이슈가 없습니다.");
         return sb.ToString();
     }
 
-    sb.AppendLine("미선점 이슈");
-    foreach (var url in data.UnclaimedUrls)
-        sb.AppendLine($" - {url}");
-
-    sb.AppendLine("\n선점된 이슈");
-    foreach (var (login, claims) in data.ClaimedMap)
+    if (mode == "user")
     {
-        sb.AppendLine($"{login}");
-        foreach (var claim in claims)
+        // user 모드: 유저별로 선점 이슈를 그룹화하여 출력
+        if (data.UnclaimedUrls.Count > 0)
         {
-            sb.AppendLine($" - {claim.Url}");
-            if (claim.Labels.Count > 0)
-                sb.AppendLine($"    라벨: {string.Join(", ", claim.Labels)}");
-            sb.AppendLine(claim.HasPr ? "   PR 생성됨" : FormatRemainingTime(claim.Remaining));
+            sb.AppendLine("미선점 이슈");
+            foreach (var url in data.UnclaimedUrls)
+            {
+                sb.AppendLine($" - {url}");
+            }
+        }
+
+        if (data.ClaimedMap.Count > 0)
+        {
+            sb.AppendLine("\n선점된 이슈");
+            foreach (var (login, claims) in data.ClaimedMap)
+            {
+                sb.AppendLine($"{login}");
+                foreach (var claim in claims)
+                {
+                    sb.AppendLine($" - {claim.Url}");
+                    if (claim.Labels.Count > 0)
+                    {
+                        sb.AppendLine($"   라벨: {string.Join(", ", claim.Labels)}");
+                    }
+                    sb.AppendLine(claim.HasPr ? "   PR 생성됨" : FormatRemainingTime(claim.Remaining));
+                }
+            }
+        }
+    }
+    else
+    {
+        // issue 모드: 이슈별로 선점자를 표시
+        // ClaimedMap(유저→이슈)을 이슈 기준으로 재구성
+        var claimedIssues = new List<(string Login, ClaimRecord Claim)>();
+        foreach (var (login, claims) in data.ClaimedMap)
+        {
+            foreach (var claim in claims)
+            {
+                claimedIssues.Add((login, claim));
+            }
+        }
+
+        // 이슈 번호 기준 정렬
+        claimedIssues = claimedIssues.OrderBy(x => x.Claim.Number).ToList();
+
+        if (claimedIssues.Count > 0)
+        {
+            sb.AppendLine("선점된 이슈");
+            foreach (var (login, claim) in claimedIssues)
+            {
+                sb.AppendLine($" #{claim.Number} {claim.Url}");
+                sb.AppendLine($"   선점자: {login}");
+                if (claim.Labels.Count > 0)
+                {
+                    sb.AppendLine($"   라벨: {string.Join(", ", claim.Labels)}");
+                }
+                sb.AppendLine(claim.HasPr ? "   PR 생성됨" : FormatRemainingTime(claim.Remaining));
+            }
+        }
+
+        if (data.UnclaimedUrls.Count > 0)
+        {
+            sb.AppendLine("\n미선점 이슈");
+            foreach (var url in data.UnclaimedUrls)
+            {
+                sb.AppendLine($" - {url}");
+            }
         }
     }
 

--- a/Services/GitHubService.cs
+++ b/Services/GitHubService.cs
@@ -227,7 +227,7 @@ namespace RepoScore.Services
         public List<string> GetPullRequestComments(int prNumber)
         {
             var query = new Octokit.GraphQL.Query()
-                .Repository(_owner, _repo)
+                .Repository(_repo, _owner)
                 .PullRequest(prNumber)
                 .Comments(first: 50)
                 .Nodes.Select(c => c.Body);
@@ -240,7 +240,7 @@ namespace RepoScore.Services
             try
             {
                 var query = new Octokit.GraphQL.Query()
-                    .Repository(_owner, _repo)
+                    .Repository(_repo, _owner)
                     .Issue(issueNumber)
                     .TimelineItems(first: 50)
                     .Nodes
@@ -314,7 +314,7 @@ namespace RepoScore.Services
         public ClaimsData GetRecentClaimsData()
         {
             var query = new Octokit.GraphQL.Query()
-                .Repository(_owner, _repo)
+                .Repository(_repo, _owner)
                 .Issues(first: 20, states: new[] { IssueState.Open }, orderBy: new IssueOrder { Field = IssueOrderField.CreatedAt, Direction = OrderDirection.Desc })
                 .Nodes.Select(issue => new
                 {


### PR DESCRIPTION
### ISSUE_ID
Closes #309

### 변경사항
- [x] `BuildClaimsReport()`에서 `mode` 파라미터를 실제로 사용하도록 수정
  - `issue` 모드: 이슈 번호 기준 정렬, 각 이슈에 선점자 표시
  - `user` 모드: 유저별 그룹화, 각 유저의 선점 이슈 목록 표시
- [x] `Services/GitHubService.cs`의 `.Repository()` 파라미터 순서 수정
  - Octokit.GraphQL `.Repository()` 시그니처가 `(name, owner)` 순서임을 확인
  - 기존 `.Repository(_owner, _repo)` → `.Repository(_repo, _owner)`로 수정
  - 대상 메서드: `GetRecentClaimsData()`, `HasLinkedPullRequest()`, `GetPullRequestComments()`
  - 이 버그로 인해 `--claims` 실행 시 항상 오류가 발생하고 있었음

### 🧪 테스트 방법
```bash
# issue 모드 — 이슈 번호 기준 정렬, 선점자 표시
dotnet run -- oss2026hnu/reposcore-cs --claims=issue --token YOUR_TOKEN

# user 모드 — 유저별 그룹화
dotnet run -- oss2026hnu/reposcore-cs --claims=user --token YOUR_TOKEN
```

issue 모드 출력 예시:
```
선점된 이슈
 #304 https://github.com/oss2026hnu/reposcore-cs/issues/304
   선점자: arror1784
   라벨: Enhancement
   남은 시간: 42:23:34

미선점 이슈
 - https://github.com/oss2026hnu/reposcore-cs/issues/305
```

user 모드 출력 예시:
```
선점된 이슈
arror1784
 - https://github.com/oss2026hnu/reposcore-cs/issues/304
   라벨: Enhancement
   남은 시간: 42:22:40
```

### 💬 참고 사항
`Services/GitHubService.cs`의 `.Repository()` 순서 수정은
`--claims` 기능이 정상 동작하기 위한 선행 조건입니다.
점수 산정 기능(`dotnet run -- owner/repo`)에는 영향 없습니다.