### PR TITLE
Program.cs 유틸리티 메서드를 Data 클래스로 분리 리팩토링

### DIFF
--- a/Data/Reportformatter.cs
+++ b/Data/Reportformatter.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using RepoScore.Services;
+
+namespace RepoScore.Data
+{
+    public static class ReportFormatter
+    {
+        public static string BuildTextReport(
+            string repo,
+            List<(string Id, int docIssues, int featBugIssues, int typoPrs, int docPrs, int featBugPrs, int Score)> reportData)
+        {
+            var rows = reportData.Select(r => new
+            {
+                Id = r.Id,
+                IssuePr = $"{r.docIssues + r.featBugIssues}/{r.typoPrs + r.docPrs + r.featBugPrs}",
+                Score = r.Score.ToString()
+            }).ToList();
+
+            string userHeader = "유저";
+            string issuePrHeader = "이슈/PR";
+            string scoreHeader = "점수";
+
+            int userWidth = Math.Max(userHeader.Length, rows.Any() ? rows.Max(x => GetDisplayWidth(x.Id)) : 0);
+            int issuePrWidth = Math.Max(issuePrHeader.Length, rows.Any() ? rows.Max(x => x.IssuePr.Length) : 0);
+            int scoreWidth = Math.Max(scoreHeader.Length, rows.Any() ? rows.Max(x => x.Score.Length) : 0);
+
+            string separator =
+                new string('-', userWidth) + "-+-" +
+                new string('-', issuePrWidth) + "-+-" +
+                new string('-', scoreWidth);
+
+            var sb = new StringBuilder();
+            sb.AppendLine($"=== {repo} 오픈소스 기여도 분석 리포트 ===");
+            sb.AppendLine($"분석 일시: {DateTime.Now:yyyy-MM-dd HH:mm}");
+            sb.AppendLine();
+
+            sb.AppendLine(
+                PadRightKorean(userHeader, userWidth) + " | " +
+                PadLeft(issuePrHeader, issuePrWidth) + " | " +
+                PadLeft(scoreHeader, scoreWidth));
+
+            sb.AppendLine(separator);
+
+            foreach (var row in rows)
+            {
+                sb.AppendLine(
+                    PadRightKorean(row.Id, userWidth) + " | " +
+                    PadLeft(row.IssuePr, issuePrWidth) + " | " +
+                    PadLeft(row.Score, scoreWidth));
+            }
+
+            return sb.ToString();
+        }
+
+        public static string BuildClaimsReport(ClaimsData data, string mode)
+        {
+            var sb = new StringBuilder();
+
+            if (data.ClaimedMap.Count == 0)
+            {
+                sb.AppendLine("최근 48시간 내 선점된 이슈가 없습니다.");
+                return sb.ToString();
+            }
+
+            sb.AppendLine("미선점 이슈");
+            foreach (var url in data.UnclaimedUrls)
+                sb.AppendLine($" - {url}");
+
+            sb.AppendLine("\n선점된 이슈");
+            foreach (var (login, claims) in data.ClaimedMap)
+            {
+                sb.AppendLine($"{login}");
+                foreach (var claim in claims)
+                {
+                    sb.AppendLine($" - {claim.Url}");
+                    if (claim.Labels.Count > 0)
+                        sb.AppendLine($"    라벨: {string.Join(", ", claim.Labels)}");
+                    sb.AppendLine(claim.HasPr ? "   PR 생성됨" : FormatRemainingTime(claim.Remaining));
+                }
+            }
+
+            return sb.ToString();
+        }
+
+        public static string FormatRemainingTime(TimeSpan remaining)
+        {
+            if (remaining <= TimeSpan.Zero) return "    기한 초과";
+            return $"   남은 시간: {(int)remaining.TotalHours:D2}:{remaining.Minutes:D2}:{remaining.Seconds:D2}";
+        }
+
+        public static string PadLeft(string text, int width)
+        {
+            return text.PadLeft(width);
+        }
+
+        public static string PadRightKorean(string text, int width)
+        {
+            int textWidth = GetDisplayWidth(text);
+            if (textWidth >= width) return text;
+
+            return text + new string(' ', width - textWidth);
+        }
+
+        public static int GetDisplayWidth(string text)
+        {
+            int width = 0;
+
+            foreach (char c in text)
+            {
+                width += c > 127 ? 2 : 1;
+            }
+
+            return width;
+        }
+    }
+}

--- a/Data/Reportformatter.cs
+++ b/Data/Reportformatter.cs
@@ -59,26 +59,55 @@ namespace RepoScore.Data
         {
             var sb = new StringBuilder();
 
-            if (data.ClaimedMap.Count == 0)
+            if (data.ClaimedMap.Count == 0 && data.UnclaimedUrls.Count == 0)
             {
-                sb.AppendLine("최근 48시간 내 선점된 이슈가 없습니다.");
-                return sb.ToString();
+                return "최근 48시간 내 선점된 이슈가 없습니다.\n";
             }
 
-            sb.AppendLine("미선점 이슈");
-            foreach (var url in data.UnclaimedUrls)
-                sb.AppendLine($" - {url}");
-
-            sb.AppendLine("\n선점된 이슈");
-            foreach (var (login, claims) in data.ClaimedMap)
+            if (mode == "user")
             {
-                sb.AppendLine($"{login}");
-                foreach (var claim in claims)
+                if (data.UnclaimedUrls.Count > 0)
                 {
-                    sb.AppendLine($" - {claim.Url}");
-                    if (claim.Labels.Count > 0)
-                        sb.AppendLine($"    라벨: {string.Join(", ", claim.Labels)}");
-                    sb.AppendLine(claim.HasPr ? "   PR 생성됨" : FormatRemainingTime(claim.Remaining));
+                    sb.AppendLine("미선점 이슈");
+                    foreach (var url in data.UnclaimedUrls) sb.AppendLine($" - {url}");
+                }
+
+                if (data.ClaimedMap.Count > 0)
+                {
+                    sb.AppendLine("\n선점된 이슈");
+                    foreach (var (login, claims) in data.ClaimedMap)
+                    {
+                        sb.AppendLine($"{login}");
+                        foreach (var claim in claims)
+                        {
+                            sb.AppendLine($" - {claim.Url}");
+                            if (claim.Labels.Count > 0) sb.AppendLine($"   라벨: {string.Join(", ", claim.Labels)}");
+                            sb.AppendLine(claim.HasPr ? "   PR 생성됨" : FormatRemainingTime(claim.Remaining));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                var claimedIssues = data.ClaimedMap.SelectMany(kv => kv.Value.Select(c => (Login: kv.Key, Claim: c)))
+                                                  .OrderBy(x => x.Claim.Number).ToList();
+
+                if (claimedIssues.Count > 0)
+                {
+                    sb.AppendLine("선점된 이슈");
+                    foreach (var (login, claim) in claimedIssues)
+                    {
+                        sb.AppendLine($" #{claim.Number} {claim.Url}");
+                        sb.AppendLine($"   선점자: {login}");
+                        if (claim.Labels.Count > 0) sb.AppendLine($"   라벨: {string.Join(", ", claim.Labels)}");
+                        sb.AppendLine(claim.HasPr ? "   PR 생성됨" : FormatRemainingTime(claim.Remaining));
+                    }
+                }
+
+                if (data.UnclaimedUrls.Count > 0)
+                {
+                    sb.AppendLine("\n미선점 이슈");
+                    foreach (var url in data.UnclaimedUrls) sb.AppendLine($" - {url}");
                 }
             }
 
@@ -87,7 +116,7 @@ namespace RepoScore.Data
 
         public static string FormatRemainingTime(TimeSpan remaining)
         {
-            if (remaining <= TimeSpan.Zero) return "    기한 초과";
+            if (remaining <= TimeSpan.Zero) return "   기한 초과";
             return $"   남은 시간: {(int)remaining.TotalHours:D2}:{remaining.Minutes:D2}:{remaining.Seconds:D2}";
         }
 

--- a/Data/Reportsorter.cs
+++ b/Data/Reportsorter.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace RepoScore.Data
+{
+    public static class ReportSorter
+    {
+        public static List<(string Id, int docIssues, int featBugIssues, int typoPrs, int docPrs, int featBugPrs, int Score)>
+        SortReportData(
+            List<(string Id, int docIssues, int featBugIssues, int typoPrs, int docPrs, int featBugPrs, int Score)> data,
+            string sortBy,
+            string sortOrder)
+        {
+            return sortBy.ToLower() switch
+            {
+                "score" => sortOrder.ToLower() == "asc"
+                    ? data.OrderBy(x => x.Score).ToList()
+                    : data.OrderByDescending(x => x.Score).ToList(),
+                "id" => sortOrder.ToLower() == "asc"
+                    ? data.OrderBy(x => x.Id).ToList()
+                    : data.OrderByDescending(x => x.Id).ToList(),
+                _ => sortOrder.ToLower() == "asc"
+                    ? data.OrderBy(x => x.Score).ToList()
+                    : data.OrderByDescending(x => x.Score).ToList()
+            };
+        }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -6,7 +6,7 @@ using System.Text;
 using Cocona;
 using RepoScore.Data;
 using RepoScore.Services;
-using Spectre.Console; // 라이브러리 추가
+using Spectre.Console;
 using System.Globalization;
 
 CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo("en-US");
@@ -30,6 +30,13 @@ CoconaApp.Run((
     output ??= "./results";
     sortBy ??= "score";
     sortOrder ??= "desc";
+
+    var allowedFormats = new[] { "csv", "txt" };
+    if (!allowedFormats.Contains(format.ToLowerInvariant()))
+    {
+        Console.Error.WriteLine($"오류: 지원하지 않는 형식입니다. csv 또는 txt를 입력해 주세요. (입력값: {format})");
+        return;
+    }
 
     string[]? parsedKeywords = keywords != null
         ? keywords.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
@@ -60,11 +67,10 @@ var cache = CacheManager.LoadCache(cachePath, repo, noCache);
                 var mode = string.IsNullOrEmpty(claims) ? "issue" : claims;
 
                 var claimsData = service.GetRecentClaimsData();
-                var report = BuildClaimsReport(claimsData, mode);
+                var report = ReportFormatter.BuildClaimsReport(claimsData, mode);
                 Console.Write(report);
                 continue;
             }
-
 
             AnsiConsole.MarkupLine($"[yellow]{repo}[/] 기여자 데이터 수집 및 분석 중...");
 
@@ -122,7 +128,6 @@ var cache = CacheManager.LoadCache(cachePath, repo, noCache);
                 }
 
                 var userClaimsToCalc = cache.UserClaims[user];
-
                 var prsToCalc = cache.UserPullRequests[user];
 
                 var featureBugPrs = prsToCalc.Where(p => p.Labels.Contains(GitHubIssuePrLabel.Bug) || p.Labels.Contains(GitHubIssuePrLabel.Enhancement)).ToList();
@@ -140,7 +145,7 @@ var cache = CacheManager.LoadCache(cachePath, repo, noCache);
             CacheManager.SaveCache(cachePath, cache, parsedKeywords);
             Console.Error.WriteLine($"캐시 갱신 및 저장 완료: {cachePath}");
 
-            reportData = SortReportData(reportData, sortBy, sortOrder);
+            reportData = ReportSorter.SortReportData(reportData, sortBy, sortOrder);
 
             // CSV 데이터 파일 생성
             var csv = new StringBuilder();
@@ -155,12 +160,11 @@ var cache = CacheManager.LoadCache(cachePath, repo, noCache);
             if (format.ToLower() == "txt")
             {
                 string txtPath = Path.Combine(repoOutput, "results.txt");
-                string txtContent = BuildTextReport(repo, reportData);
+                string txtContent = ReportFormatter.BuildTextReport(repo, reportData);
 
                 File.WriteAllText(txtPath, txtContent, Encoding.UTF8);
                 Console.Error.WriteLine($"가독성 리포트(TXT) 추가 저장 완료: {txtPath}");
 
-                // 화면에도 Spectre.Console을 사용하여 예쁘게 출력
                 PrintSpectreTable(repo, reportData);
             }
         }
@@ -171,27 +175,6 @@ var cache = CacheManager.LoadCache(cachePath, repo, noCache);
     }
 });
 
-static List<(string Id, int docIssues, int featBugIssues, int typoPrs, int docPrs, int featBugPrs, int Score)>
-SortReportData(List<(string Id, int docIssues, int featBugIssues, int typoPrs, int docPrs, int featBugPrs, int Score)> data,
-                string sortBy, string sortOrder)
-{
-    var sorted = sortBy.ToLower() switch
-    {
-        "score" => sortOrder.ToLower() == "asc"
-            ? data.OrderBy(x => x.Score).ToList()
-            : data.OrderByDescending(x => x.Score).ToList(),
-        "id" => sortOrder.ToLower() == "asc"
-            ? data.OrderBy(x => x.Id).ToList()
-            : data.OrderByDescending(x => x.Id).ToList(),
-        _ => sortOrder.ToLower() == "asc"
-            ? data.OrderBy(x => x.Score).ToList()
-            : data.OrderByDescending(x => x.Score).ToList()
-    };
-
-    return sorted;
-}
-
-// Spectre.Console을 사용하여 터미널에 직접 출력하는 함수
 static void PrintSpectreTable(string repo, List<(string Id, int docIssues, int featBugIssues, int typoPrs, int docPrs, int featBugPrs, int Score)> reportData)
 {
     var table = new Table();
@@ -212,98 +195,4 @@ static void PrintSpectreTable(string repo, List<(string Id, int docIssues, int f
     }
 
     AnsiConsole.Write(table);
-}
-
-static string BuildTextReport(
-    string repo,
-    List<(string Id, int docIssues, int featBugIssues, int typoPrs, int docPrs, int featBugPrs, int Score)> reportData)
-{
-    var console = AnsiConsole.Create(new AnsiConsoleSettings
-    {
-        Ansi = AnsiSupport.No,
-        Interactive = InteractionSupport.No
-    });
-
-    var recorder = new Recorder(console);
-
-    var table = new Table();
-    table.Title($"=== {repo} 오픈소스 기여도 분석 리포트 ===");
-    table.Caption($"분석 일시: {DateTime.Now:yyyy-MM-dd HH:mm}");
-
-    table.AddColumn("유저");
-    table.AddColumn("이슈/PR");
-    table.AddColumn("점수");
-
-    foreach (var r in reportData)
-    {
-        table.AddRow(r.Id, $"{r.docIssues + r.featBugIssues}/{r.typoPrs + r.docPrs + r.featBugPrs}", r.Score.ToString());
-    }
-
-    recorder.Write(table);
-    return recorder.ExportText();
-}
-
-static string BuildClaimsReport(ClaimsData data, string mode)
-{
-    var sb = new StringBuilder();
-
-    if (data.ClaimedMap.Count == 0 && data.UnclaimedUrls.Count == 0)
-    {
-        return "최근 48시간 내 선점된 이슈가 없습니다.\n";
-    }
-
-    if (mode == "user")
-    {
-        if (data.UnclaimedUrls.Count > 0)
-        {
-            sb.AppendLine("[yellow]미선점 이슈[/]");
-            foreach (var url in data.UnclaimedUrls) sb.AppendLine($" - {url}");
-        }
-
-        if (data.ClaimedMap.Count > 0)
-        {
-            sb.AppendLine("\n[green]선점된 이슈[/]");
-            foreach (var (login, claims) in data.ClaimedMap)
-            {
-                sb.AppendLine($"[bold]{login}[/]");
-                foreach (var claim in claims)
-                {
-                    sb.AppendLine($" - {claim.Url}");
-                    if (claim.Labels.Count > 0) sb.AppendLine($"   라벨: {string.Join(", ", claim.Labels)}");
-                    sb.AppendLine(claim.HasPr ? "   PR 생성됨" : FormatRemainingTime(claim.Remaining));
-                }
-            }
-        }
-    }
-    else
-    {
-        var claimedIssues = data.ClaimedMap.SelectMany(kv => kv.Value.Select(c => (Login: kv.Key, Claim: c)))
-                                          .OrderBy(x => x.Claim.Number).ToList();
-
-        if (claimedIssues.Count > 0)
-        {
-            sb.AppendLine("[green]선점된 이슈[/]");
-            foreach (var (login, claim) in claimedIssues)
-            {
-                sb.AppendLine($" #{claim.Number} {claim.Url}");
-                sb.AppendLine($"   선점자: {login}");
-                if (claim.Labels.Count > 0) sb.AppendLine($"   라벨: {string.Join(", ", claim.Labels)}");
-                sb.AppendLine(claim.HasPr ? "   PR 생성됨" : FormatRemainingTime(claim.Remaining));
-            }
-        }
-
-        if (data.UnclaimedUrls.Count > 0)
-        {
-            sb.AppendLine("\n[yellow]미선점 이슈[/]");
-            foreach (var url in data.UnclaimedUrls) sb.AppendLine($" - {url}");
-        }
-    }
-
-    return sb.ToString();
-}
-
-static string FormatRemainingTime(TimeSpan remaining)
-{
-    if (remaining <= TimeSpan.Zero) return "   기한 초과";
-    return $"   남은 시간: {(int)remaining.TotalHours:D2}:{remaining.Minutes:D2}:{remaining.Seconds:D2}";
 }

--- a/Program.cs
+++ b/Program.cs
@@ -27,13 +27,6 @@ CoconaApp.Run((
     string ownerName = parts[0];
     string repoName = parts[1];
 
-    var allowedFormats = new[] { "csv", "txt" };
-    if (!allowedFormats.Contains(format.ToLowerInvariant()))
-    {
-        Console.Error.WriteLine($"오류: 지원하지 않는 형식입니다. csv 또는 txt를 입력해 주세요. (입력값: {format})");
-        return;
-    }
-
     string[]? parsedKeywords = keywords != null
         ? keywords.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
         : null;
@@ -48,7 +41,7 @@ CoconaApp.Run((
             var mode = string.IsNullOrEmpty(claims) ? "issue" : claims;
 
             var claimsData = service.GetRecentClaimsData();
-            var report = BuildClaimsReport(claimsData, mode);
+            var report = ReportFormatter.BuildClaimsReport(claimsData, mode);
             Console.Write(report);
             return;
         }
@@ -120,7 +113,7 @@ CoconaApp.Run((
         CacheManager.SaveCache(cachePath, cache);
         Console.Error.WriteLine($"캐시 갱신 및 저장 완료: {cachePath}");
 
-        reportData = SortReportData(reportData, sortBy, sortOrder);
+        reportData = ReportSorter.SortReportData(reportData, sortBy, sortOrder);
 
         // CSV 데이터 파일 생성
         var csv = new StringBuilder();
@@ -135,7 +128,7 @@ CoconaApp.Run((
         if (format.ToLower() == "txt")
         {
             string txtPath = Path.Combine(output, "results.txt");
-            string txtContent = BuildTextReport(repo, reportData);
+            string txtContent = ReportFormatter.BuildTextReport(repo, reportData);
 
             File.WriteAllText(txtPath, txtContent, Encoding.UTF8);
             Console.Error.WriteLine($"가독성 리포트(TXT) 추가 저장 완료: {txtPath}");
@@ -146,185 +139,3 @@ CoconaApp.Run((
         Console.Error.WriteLine($"데이터 처리 중 오류 발생: {ex.Message}");
     }
 });
-
-static List<(string Id, int docIssues, int featBugIssues, int typoPrs, int docPrs, int featBugPrs, int Score)>
-SortReportData(List<(string Id, int docIssues, int featBugIssues, int typoPrs, int docPrs, int featBugPrs, int Score)> data,
-                string sortBy, string sortOrder)
-{
-    var sorted = sortBy.ToLower() switch
-    {
-        "score" => sortOrder.ToLower() == "asc"
-            ? data.OrderBy(x => x.Score).ToList()
-            : data.OrderByDescending(x => x.Score).ToList(),
-        "id" => sortOrder.ToLower() == "asc"
-            ? data.OrderBy(x => x.Id).ToList()
-            : data.OrderByDescending(x => x.Id).ToList(),
-        _ => sortOrder.ToLower() == "asc"
-            ? data.OrderBy(x => x.Score).ToList()
-            : data.OrderByDescending(x => x.Score).ToList()
-    };
-
-    return sorted;
-}
-
-static string BuildTextReport(
-    string repo,
-    List<(string Id, int docIssues, int featBugIssues, int typoPrs, int docPrs, int featBugPrs, int Score)> reportData)
-{
-    var rows = reportData.Select(r => new
-    {
-        Id = r.Id,
-        IssuePr = $"{r.docIssues + r.featBugIssues}/{r.typoPrs + r.docPrs + r.featBugPrs}",
-        Score = r.Score.ToString()
-    }).ToList();
-
-    string userHeader = "유저";
-    string issuePrHeader = "이슈/PR";
-    string scoreHeader = "점수";
-
-    int userWidth = Math.Max(userHeader.Length, rows.Any() ? rows.Max(x => x.Id.Length) : 0);
-    int issuePrWidth = Math.Max(issuePrHeader.Length, rows.Any() ? rows.Max(x => x.IssuePr.Length) : 0);
-    int scoreWidth = Math.Max(scoreHeader.Length, rows.Any() ? rows.Max(x => x.Score.Length) : 0);
-
-    string separator =
-        new string('-', userWidth) + "-+-" +
-        new string('-', issuePrWidth) + "-+-" +
-        new string('-', scoreWidth);
-
-    var sb = new StringBuilder();
-    sb.AppendLine($"=== {repo} 오픈소스 기여도 분석 리포트 ===");
-    sb.AppendLine($"분석 일시: {DateTime.Now:yyyy-MM-dd HH:mm}");
-    sb.AppendLine();
-
-    sb.AppendLine(
-        PadRightKorean(userHeader, userWidth) + " | " +
-        PadLeft(issuePrHeader, issuePrWidth) + " | " +
-        PadLeft(scoreHeader, scoreWidth));
-
-    sb.AppendLine(separator);
-
-    foreach (var row in rows)
-    {
-        sb.AppendLine(
-            PadRightKorean(row.Id, userWidth) + " | " +
-            PadLeft(row.IssuePr, issuePrWidth) + " | " +
-            PadLeft(row.Score, scoreWidth));
-    }
-
-    return sb.ToString();
-}
-
-static string BuildClaimsReport(ClaimsData data, string mode)
-{
-    var sb = new StringBuilder();
-
-    if (data.ClaimedMap.Count == 0 && data.UnclaimedUrls.Count == 0)
-    {
-        sb.AppendLine("최근 48시간 내 선점된 이슈가 없습니다.");
-        return sb.ToString();
-    }
-
-    if (mode == "user")
-    {
-        // user 모드: 유저별로 선점 이슈를 그룹화하여 출력
-        if (data.UnclaimedUrls.Count > 0)
-        {
-            sb.AppendLine("미선점 이슈");
-            foreach (var url in data.UnclaimedUrls)
-            {
-                sb.AppendLine($" - {url}");
-            }
-        }
-
-        if (data.ClaimedMap.Count > 0)
-        {
-            sb.AppendLine("\n선점된 이슈");
-            foreach (var (login, claims) in data.ClaimedMap)
-            {
-                sb.AppendLine($"{login}");
-                foreach (var claim in claims)
-                {
-                    sb.AppendLine($" - {claim.Url}");
-                    if (claim.Labels.Count > 0)
-                    {
-                        sb.AppendLine($"   라벨: {string.Join(", ", claim.Labels)}");
-                    }
-                    sb.AppendLine(claim.HasPr ? "   PR 생성됨" : FormatRemainingTime(claim.Remaining));
-                }
-            }
-        }
-    }
-    else
-    {
-        // issue 모드: 이슈별로 선점자를 표시
-        // ClaimedMap(유저→이슈)을 이슈 기준으로 재구성
-        var claimedIssues = new List<(string Login, ClaimRecord Claim)>();
-        foreach (var (login, claims) in data.ClaimedMap)
-        {
-            foreach (var claim in claims)
-            {
-                claimedIssues.Add((login, claim));
-            }
-        }
-
-        // 이슈 번호 기준 정렬
-        claimedIssues = claimedIssues.OrderBy(x => x.Claim.Number).ToList();
-
-        if (claimedIssues.Count > 0)
-        {
-            sb.AppendLine("선점된 이슈");
-            foreach (var (login, claim) in claimedIssues)
-            {
-                sb.AppendLine($" #{claim.Number} {claim.Url}");
-                sb.AppendLine($"   선점자: {login}");
-                if (claim.Labels.Count > 0)
-                {
-                    sb.AppendLine($"   라벨: {string.Join(", ", claim.Labels)}");
-                }
-                sb.AppendLine(claim.HasPr ? "   PR 생성됨" : FormatRemainingTime(claim.Remaining));
-            }
-        }
-
-        if (data.UnclaimedUrls.Count > 0)
-        {
-            sb.AppendLine("\n미선점 이슈");
-            foreach (var url in data.UnclaimedUrls)
-            {
-                sb.AppendLine($" - {url}");
-            }
-        }
-    }
-
-    return sb.ToString();
-}
-
-static string PadLeft(string text, int width)
-{
-    return text.PadLeft(width);
-}
-
-static string PadRightKorean(string text, int width)
-{
-    int textWidth = GetDisplayWidth(text);
-    if (textWidth >= width) return text;
-
-    return text + new string(' ', width - textWidth);
-}
-
-static int GetDisplayWidth(string text)
-{
-    int width = 0;
-
-    foreach (char c in text)
-    {
-        width += c > 127 ? 2 : 1;
-    }
-
-    return width;
-}
-
-static string FormatRemainingTime(TimeSpan remaining)
-{
-    if (remaining <= TimeSpan.Zero) return "    기한 초과";
-    return $"   남은 시간: {(int)remaining.TotalHours:D2}:{remaining.Minutes:D2}:{remaining.Seconds:D2}";
-}

--- a/Program.cs
+++ b/Program.cs
@@ -6,7 +6,7 @@ using System.Text;
 using Cocona;
 using RepoScore.Data;
 using RepoScore.Services;
-using Spectre.Console;
+using Spectre.Console; // 라이브러리 추가
 using System.Globalization;
 
 CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo("en-US");
@@ -18,7 +18,7 @@ CoconaApp.Run((
 [Option('f', Description = "출력 형식 (csv, txt)")] string? format = null,
 [Option('o', Description = "출력 디렉토리 경로")] string? output = null,
 [Option(Description = "정렬 기준 (score | id)")] string? sortBy = null,
-[Option(Description = "정렬 방법 (asc | desc)")] string? sortOrder = null,
+[Option(Description = "정렬 방법 (asc | desc)")] string? sortOrder= null,
 [Option(Description = "이슈 선점 키워드 (쉼표 구분, 미입력시 기본값 사용)")] string? keywords = null,
 [Option(Description = "캐시를 무시하고 전체 데이터를 다시 수집할지 여부")] bool noCache = false
 ) =>
@@ -43,12 +43,12 @@ CoconaApp.Run((
         string ownerName = parts[0];
         string repoName = parts[1];
 
-        string repoOutput = repos.Length > 1
-            ? Path.Combine(output, $"{ownerName}_{repoName}")
-            : output;
-        if (!Directory.Exists(repoOutput)) Directory.CreateDirectory(repoOutput);
-        string cachePath = Path.Combine(repoOutput, "cache.json");
-        var cache = CacheManager.LoadCache(cachePath, repo, noCache);
+string repoOutput = repos.Length > 1
+    ? Path.Combine(output, $"{ownerName}_{repoName}")
+    : output;
+if (!Directory.Exists(repoOutput)) Directory.CreateDirectory(repoOutput);
+string cachePath = Path.Combine(repoOutput, "cache.json");
+var cache = CacheManager.LoadCache(cachePath, repo, noCache);
 
         var service = new GitHubService(ownerName, repoName, token, parsedKeywords);
 
@@ -64,6 +64,7 @@ CoconaApp.Run((
                 Console.Write(report);
                 continue;
             }
+
 
             AnsiConsole.MarkupLine($"[yellow]{repo}[/] 기여자 데이터 수집 및 분석 중...");
 
@@ -121,6 +122,7 @@ CoconaApp.Run((
                 }
 
                 var userClaimsToCalc = cache.UserClaims[user];
+
                 var prsToCalc = cache.UserPullRequests[user];
 
                 var featureBugPrs = prsToCalc.Where(p => p.Labels.Contains(GitHubIssuePrLabel.Bug) || p.Labels.Contains(GitHubIssuePrLabel.Enhancement)).ToList();
@@ -158,6 +160,7 @@ CoconaApp.Run((
                 File.WriteAllText(txtPath, txtContent, Encoding.UTF8);
                 Console.Error.WriteLine($"가독성 리포트(TXT) 추가 저장 완료: {txtPath}");
 
+                // 화면에도 Spectre.Console을 사용하여 예쁘게 출력
                 PrintSpectreTable(repo, reportData);
             }
         }
@@ -188,6 +191,7 @@ SortReportData(List<(string Id, int docIssues, int featBugIssues, int typoPrs, i
     return sorted;
 }
 
+// Spectre.Console을 사용하여 터미널에 직접 출력하는 함수
 static void PrintSpectreTable(string repo, List<(string Id, int docIssues, int featBugIssues, int typoPrs, int docPrs, int featBugPrs, int Score)> reportData)
 {
     var table = new Table();
@@ -259,10 +263,10 @@ static string BuildClaimsReport(ClaimsData data, string mode)
         if (data.ClaimedMap.Count > 0)
         {
             sb.AppendLine("\n[green]선점된 이슈[/]");
-            foreach (var (login, claimList) in data.ClaimedMap)
+            foreach (var (login, claims) in data.ClaimedMap)
             {
                 sb.AppendLine($"[bold]{login}[/]");
-                foreach (var claim in claimList)
+                foreach (var claim in claims)
                 {
                     sb.AppendLine($" - {claim.Url}");
                     if (claim.Labels.Count > 0) sb.AppendLine($"   라벨: {string.Join(", ", claim.Labels)}");


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #314 
 
### 변경사항
 
- [x] `Data/ReportFormatter.cs` 신규 생성 — `BuildTextReport`, `BuildClaimsReport`, `PadLeft`, `PadRightKorean`, `GetDisplayWidth`, `FormatRemainingTime` 이동
- [x] `Data/ReportSorter.cs` 신규 생성 — `SortReportData` 이동
- [x] `Program.cs` — 상기 static 메서드 제거, 호출부를 `ReportFormatter.*` / `ReportSorter.*` 로 교체
### 🧪 테스트 방법
 
```bash
dotnet build
dotnet run -- oss2026hnu/reposcore-cs --token $GITHUB_TOKEN
dotnet run -- oss2026hnu/reposcore-cs --token $GITHUB_TOKEN -f txt
dotnet run -- oss2026hnu/reposcore-cs --token $GITHUB_TOKEN --claims=issue
```
 
### 💬 참고 사항
