### PR TITLE
dotnet-guide.md 6.6절 현재 프로젝트 예시에 Octokit.GraphQL 추가

### DIFF
--- a/docs/dotnet-guide.md
+++ b/docs/dotnet-guide.md
@@ -178,9 +178,13 @@ dotnet restore
 6.6 현재 프로젝트 예시
 
 ```bash
-dotnet add package Octokit
+dotnet add package Octokit.GraphQL --prerelease
 dotnet add package Cocona
 ```
+
+> **참고:** 현재 프로젝트는 GitHub GraphQL API를 주력으로 사용하므로 `Octokit.GraphQL`을 설치합니다.  
+> 기여자 목록 조회(`GetAllContributors`) 등 일부 기능에서는 REST 클라이언트(`Octokit`)도 내부적으로 함께 사용됩니다.
+
 6.7 정리
 - 패키지는 dotnet add package로 설치합니다.
 - 의존성은 .csproj 파일에서 관리됩니다.


### PR DESCRIPTION
### ISSUE_ID
Closes #337

### 변경사항
- [x] `docs/dotnet-guide.md` 6.6절 현재 프로젝트 예시 수정
  - `Octokit` → `Octokit.GraphQL --prerelease` 로 교체
  - `Octokit` REST는 `GetAllContributors()` 등 일부 기능에서 내부적으로 사용 중임을 안내하는 참고 노트 추가
