### PR TITLE
Load cache with optional bypass for fresh data collection

### DIFF
--- a/Data/CacheManager.cs
+++ b/Data/CacheManager.cs
@@ -26,8 +26,14 @@ namespace RepoScore.Data
             Converters = { new JsonStringEnumConverter() }
         };
 
-        public static RepoCache LoadCache(string cacheFilePath, string repoName)
+        public static RepoCache LoadCache(string cacheFilePath, string repoName, bool noCache = false)
         {
+            if (noCache)
+            {
+                Console.Error.WriteLine("ℹ️  캐시를 무시하고 전체 데이터를 다시 수집합니다.");
+                return new RepoCache { Repository = repoName };
+            }
+
             if (!File.Exists(cacheFilePath))
             {
                 return new RepoCache { Repository = repoName };
@@ -46,7 +52,7 @@ namespace RepoScore.Data
             }
             catch
             {
-                Console.WriteLine("⚠️ 기존 캐시 파일이 손상되어 새로 수집을 시작합니다.");
+                Console.Error.WriteLine("⚠️ 기존 캐시 파일이 손상되어 새로 수집을 시작합니다.");
                 return new RepoCache { Repository = repoName };
             }
         }
@@ -57,7 +63,7 @@ namespace RepoScore.Data
             {
                 Directory.CreateDirectory(dir);
             }
-            
+
             cacheData.LastAnalyzedAt = DateTimeOffset.UtcNow;
 
             string json = JsonSerializer.Serialize(cacheData, s_jsonOptions);

--- a/Program.cs
+++ b/Program.cs
@@ -11,10 +11,10 @@ CoconaApp.Run((
 [Argument(Description = "대상 저장소 목록 (예: owner/repo1 owner/repo2)")] string[] repos,
 [Option('t', Description = "GitHub Token (미입력시 GITHUB_TOKEN 사용)")] string? token = null,
 [Option(Description = "최근 이슈 선점 현황 조회 (issue|user)")] string? claims = null,
-[Option('f', Description = "출력 형식 (csv, txt)")] string? format,
-[Option('o', Description = "출력 디렉토리 경로")] string? output,
-[Option(Description = "정렬 기준 (score | id)")] string? sortBy,
-[Option(Description = "정렬 방법 (asc | desc)")] string? sortOrder,
+[Option('f', Description = "출력 형식 (csv, txt)")] string? format = null,
+[Option('o', Description = "출력 디렉토리 경로")] string? output = null,
+[Option(Description = "정렬 기준 (score | id)")] string? sortBy = null,
+[Option(Description = "정렬 방법 (asc | desc)")] string? sortOrder= null,
 [Option(Description = "이슈 선점 키워드 (쉼표 구분, 미입력시 기본값 사용)")] string? keywords = null,
 [Option(Description = "캐시를 무시하고 전체 데이터를 다시 수집할지 여부")] bool noCache = false
 ) =>

--- a/Program.cs
+++ b/Program.cs
@@ -70,10 +70,6 @@ var cache = CacheManager.LoadCache(cachePath, repo, noCache);
 
             Console.Error.WriteLine($"{repo} 기여자 데이터 수집 및 분석 중...");
 
-            if (!Directory.Exists(repoOutput)) Directory.CreateDirectory(repoOutput);
-            string cachePath = Path.Combine(repoOutput, "cache.json");
-            var cache = CacheManager.LoadCache(cachePath, repo);
-
             DateTimeOffset? since = cache.LastAnalyzedAt > DateTimeOffset.MinValue ? cache.LastAnalyzedAt : null;
 
             if (since.HasValue)

--- a/Program.cs
+++ b/Program.cs
@@ -15,7 +15,8 @@ CoconaApp.Run((
     [Option('o', Description = "출력 디렉토리 경로")] string output = "./results",
     [Option(Description = "정렬 기준 (score | id)")] string sortBy = "score",
     [Option(Description = "정렬 방법 (asc | desc)")] string sortOrder = "desc",
-    [Option(Description = "이슈 선점 키워드 (쉼표 구분, 미입력시 기본값 사용)")] string? keywords = null
+    [Option(Description = "이슈 선점 키워드 (쉼표 구분, 미입력시 기본값 사용)")] string? keywords = null,
+    [Option(Description = "캐시를 무시하고 전체 데이터를 다시 수집할지 여부")] bool noCache = false
 ) =>
 {
     token ??= Environment.GetEnvironmentVariable("GITHUB_TOKEN");
@@ -57,7 +58,7 @@ CoconaApp.Run((
 
         if (!Directory.Exists(output)) Directory.CreateDirectory(output);
         string cachePath = Path.Combine(output, "cache.json");
-        var cache = CacheManager.LoadCache(cachePath, repo);
+        var cache = CacheManager.LoadCache(cachePath, repo, noCache);
 
         DateTimeOffset? since = cache.LastAnalyzedAt > DateTimeOffset.MinValue ? cache.LastAnalyzedAt : null;
 


### PR DESCRIPTION
### ISSUE_ID
Closes https://github.com/oss2026hnu/reposcore-cs/issues/321

### 변경사항
- [x] CLI 실행 시 캐시를 무시할 수 있는 `--no-cache` 불리언 옵션 추가
- [x] `CacheManager.LoadCache()` 로직을 수정하여 `noCache` 플래그 활성 시 기존 `cache.json`을 무시하고 강제로 Full Refresh를 수행하도록 변경
- [x] 캐시 무시 시 사용자에게 안내 메시지(`ℹ️ 캐시를 무시하고 전체 데이터를 다시 수집합니다.`) 출력 및 로그 출력 스트림을 `Console.Error`로 통일하여 결과 데이터와 분리

### 🧪 테스트 방법
- `dotnet run -- --help` 명령어를 통해 `--no-cache` 옵션이 정상적으로 등록되었는지 확인했습니다.
- 로컬에 `cache.json`이 있는 상태에서 `--no-cache` 옵션을 사용하여 실행했을 때, 기존 캐시를 불러오지 않고 "전체 데이터를 수집합니다"라는 안내와 함께 새로 분석이 시작되는 것을 확인했습니다.
- 분석 완료 후 새롭게 수집된 데이터로 `cache.json`이 정상적으로 갱신되는 것을 확인했습니다.

### 💬 참고 사항
- Cocona의 불리언 옵션을 활용하였으므로, `--no-cache` 또는 `--no-cache true/false` 형태로 사용 가능합니다.
- 사용자가 캐시 위치를 직접 찾아 지우지 않아도 명령어만으로 데이터 정제가 가능해져 도구의 사용성이 개선되었습니다.