### PR TITLE
깃헙 정보 조회 쿼리 구조 개선 및 중복된 클라이언트 필터링 제거

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -97,13 +97,9 @@ CoconaApp.Run((
                 else cache.UserPullRequests[user].Add(npr);
             }
 
-            var userClaimsToCalc = cache.UserClaims[user]
-                .Where(c => c.ClosedReason != IssueClosedStateReason.NotPlanned && c.ClosedReason != IssueClosedStateReason.Duplicate)
-                .ToList();
+            var userClaimsToCalc = cache.UserClaims[user];
 
-            var prsToCalc = cache.UserPullRequests[user]
-                .Where(p => p.IsMerged)
-                .ToList();
+            var prsToCalc = cache.UserPullRequests[user];
 
             var featureBugPrs = prsToCalc.Where(p => p.Labels.Contains(GitHubIssuePrLabel.Bug) || p.Labels.Contains(GitHubIssuePrLabel.Enhancement)).ToList();
             var docPrs = prsToCalc.Where(p => p.Labels.Contains(GitHubIssuePrLabel.Documentation)).ToList();

--- a/Services/GitHubService.cs
+++ b/Services/GitHubService.cs
@@ -84,7 +84,7 @@ namespace RepoScore.Services
         }
         public List<PRRecord> GetPullRequests(string authorLogin, DateTimeOffset? since = null)
         {
-            string searchString = $"repo:{_owner}/{_repo} is:pr author:{authorLogin}";
+            string searchString = $"repo:{_owner}/{_repo} is:pr is:merged author:{authorLogin}";
             if (since.HasValue)
             {
                 searchString += $" updated:>={since.Value.ToUniversalTime():yyyy-MM-ddTHH:mm:ssZ}";
@@ -144,7 +144,7 @@ namespace RepoScore.Services
                 }
             }";
 
-            string searchString = $"repo:{_owner}/{_repo} is:issue author:{authorLogin}";
+            string searchString = $"repo:{_owner}/{_repo} is:issue author:{authorLogin} -reason:\"not planned\" -reason:\"duplicate\"";
             if (since.HasValue)
             {
                 searchString += $" updated:>={since.Value.ToUniversalTime():yyyy-MM-ddTHH:mm:ssZ}";


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
#306

### 변경사항
- GetClaims에서 GraphQL search query에 -reason:"not planned" -reason:"duplicate" 조건 추가하여 불필요한 이슈를 서버 단에서 제외
- GetPullRequests에서 GraphQL search query에 is:merged 조건 추가하여 병합된 PR만 조회하도록 수정
- Program.cs 파일 내의 쿼리 결과에서 필터링하는 중복된 부분의 코드 제거

### 🧪 테스트 방법 (선택 사항)
dotnet run -- oss2026hnu/reposcore-cs 을 실행하여 정상적으로 결과가 출력되는지 확인

### 💬 참고 사항 (선택 사항)
이 PR은 이전 커밋에서 다른 변경사항이 함께 포함되었던 부분을 분리하여, 다시 별도로 정리 후 PR 한 것입니다.

초기에 하나의 PR(#328)에 서버 단 필터링 및 중복 클라이언트 필터링 제거와  
Octokit 문서 수정이 함께 포함되는 문제가 발생하여, 변경사항 단위 분리를 위해 PR을 재구성하였습니다.

이에 따라 기존 PR(#328)은 종료하고,  
변경사항을 기능별로 분리하여  
현재 PR인 #340(서버 단 필터링 및 중복 클라이언트 필터링 제거)로 새롭게 생성하였습니다.
