### PR TITLE
feat: CLI에서 여러 저장소를 argument로 입력받을 수 있도록 구조 변경

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -8,24 +8,23 @@ using RepoScore.Data;
 using RepoScore.Services;
 
 CoconaApp.Run((
-    [Argument(Description = "대상 저장소 (예: owner/repo)")] string repo,
-    [Option('t', Description = "GitHub Token (미입력시 GITHUB_TOKEN 사용)")] string? token = null,
-    [Option(Description = "최근 이슈 선점 현황 조회 (issue|user)")] string? claims = null,
-    [Option('f', Description = "출력 형식 (csv, txt)")] string format = "csv",
-    [Option('o', Description = "출력 디렉토리 경로")] string output = "./results",
-    [Option(Description = "정렬 기준 (score | id)")] string sortBy = "score",
-    [Option(Description = "정렬 방법 (asc | desc)")] string sortOrder = "desc",
-    [Option(Description = "이슈 선점 키워드 (쉼표 구분, 미입력시 기본값 사용)")] string? keywords = null
+    [Option('t', Description = "GitHub Token (미입력시 GITHUB_TOKEN 사용)")] string? token,
+    [Option(Description = "최근 이슈 선점 현황 조회 (issue|user)")] string? claims,
+    [Option('f', Description = "출력 형식 (csv, txt)")] string? format,
+    [Option('o', Description = "출력 디렉토리 경로")] string? output,
+    [Option(Description = "정렬 기준 (score | id)")] string? sortBy,
+    [Option(Description = "정렬 방법 (asc | desc)")] string? sortOrder,
+    [Option(Description = "이슈 선점 키워드 (쉼표 구분, 미입력시 기본값 사용)")] string? keywords,
+    [Argument(Description = "대상 저장소 목록 (예: owner/repo1 owner/repo2)")] string[] repos
 ) =>
 {
     token ??= Environment.GetEnvironmentVariable("GITHUB_TOKEN");
     if (string.IsNullOrEmpty(token)) { Console.Error.WriteLine("오류: GitHub 토큰이 필요합니다."); return; }
 
-    var parts = repo.Split('/');
-    if (parts.Length != 2) { Console.Error.WriteLine("오류: 저장소 이름은 'owner/repo' 형식이어야 합니다."); return; }
-
-    string ownerName = parts[0];
-    string repoName = parts[1];
+    format ??= "csv";
+    output ??= "./results";
+    sortBy ??= "score";
+    sortOrder ??= "desc";
 
     var allowedFormats = new[] { "csv", "txt" };
     if (!allowedFormats.Contains(format.ToLowerInvariant()))
@@ -38,112 +37,125 @@ CoconaApp.Run((
         ? keywords.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
         : null;
 
-    var service = new GitHubService(ownerName, repoName, token, parsedKeywords);
-
-    try
+    foreach (var repo in repos)
     {
-        if (claims != null)
+        var parts = repo.Split('/');
+        if (parts.Length != 2) { Console.Error.WriteLine($"오류: '{repo}'는 'owner/repo' 형식이 아닙니다. 건너뜁니다."); continue; }
+
+        string ownerName = parts[0];
+        string repoName = parts[1];
+
+        string repoOutput = repos.Length > 1
+            ? Path.Combine(output, $"{ownerName}_{repoName}")
+            : output;
+
+        var service = new GitHubService(ownerName, repoName, token, parsedKeywords);
+
+        try
         {
-            Console.Error.WriteLine($"[{ownerName}/{repoName}] 최근 이슈 선점 현황을 조회합니다...\n");
-            var mode = string.IsNullOrEmpty(claims) ? "issue" : claims;
-
-            var claimsData = service.GetRecentClaimsData();
-            var report = BuildClaimsReport(claimsData, mode);
-            Console.Write(report);
-            return;
-        }
-
-        Console.Error.WriteLine($"{repo} 기여자 데이터 수집 및 분석 중...");
-
-        if (!Directory.Exists(output)) Directory.CreateDirectory(output);
-        string cachePath = Path.Combine(output, "cache.json");
-        var cache = CacheManager.LoadCache(cachePath, repo);
-
-        DateTimeOffset? since = cache.LastAnalyzedAt > DateTimeOffset.MinValue ? cache.LastAnalyzedAt : null;
-
-        if (since.HasValue)
-        {
-            Console.Error.WriteLine($"기존 캐시 존재: {since.Value.ToLocalTime():yyyy-MM-dd HH:mm}");
-        }
-        else
-        {
-            Console.Error.WriteLine("기존 캐시 없음: 전체 데이터를 수집합니다.");
-        }
-
-        List<string> contributors = service.GetAllContributors();
-        if (contributors.Count == 0) { Console.Error.WriteLine("조회된 기여자가 없습니다."); return; }
-
-        var reportData = new List<(string Id, int docIssues, int featBugIssues, int typoPrs, int docPrs, int featBugPrs, int Score)>();
-
-        foreach (var user in contributors)
-        {
-            var newClaims = service.GetClaims(user, since);
-            var newPrs = service.GetPullRequests(user, since);
-
-            if (!cache.UserClaims.ContainsKey(user)) cache.UserClaims[user] = new List<ClaimRecord>();
-            if (!cache.UserPullRequests.ContainsKey(user)) cache.UserPullRequests[user] = new List<PRRecord>();
-
-            foreach (var nc in newClaims)
+            if (claims != null)
             {
-                int index = cache.UserClaims[user].FindIndex(c => c.Number == nc.Number);
-                if (index >= 0) cache.UserClaims[user][index] = nc;
-                else cache.UserClaims[user].Add(nc);
+                Console.Error.WriteLine($"[{ownerName}/{repoName}] 최근 이슈 선점 현황을 조회합니다...\n");
+                var mode = string.IsNullOrEmpty(claims) ? "issue" : claims;
+
+                var claimsData = service.GetRecentClaimsData();
+                var report = BuildClaimsReport(claimsData, mode);
+                Console.Write(report);
+                continue;
             }
 
-            foreach (var npr in newPrs)
+            Console.Error.WriteLine($"{repo} 기여자 데이터 수집 및 분석 중...");
+
+            if (!Directory.Exists(repoOutput)) Directory.CreateDirectory(repoOutput);
+            string cachePath = Path.Combine(repoOutput, "cache.json");
+            var cache = CacheManager.LoadCache(cachePath, repo);
+
+            DateTimeOffset? since = cache.LastAnalyzedAt > DateTimeOffset.MinValue ? cache.LastAnalyzedAt : null;
+
+            if (since.HasValue)
             {
-                int index = cache.UserPullRequests[user].FindIndex(p => p.Number == npr.Number);
-                if (index >= 0) cache.UserPullRequests[user][index] = npr;
-                else cache.UserPullRequests[user].Add(npr);
+                Console.Error.WriteLine($"기존 캐시 존재: {since.Value.ToLocalTime():yyyy-MM-dd HH:mm}");
+            }
+            else
+            {
+                Console.Error.WriteLine("기존 캐시 없음: 전체 데이터를 수집합니다.");
             }
 
-            var userClaimsToCalc = cache.UserClaims[user]
-                .Where(c => c.ClosedReason != IssueClosedStateReason.NotPlanned && c.ClosedReason != IssueClosedStateReason.Duplicate)
-                .ToList();
+            List<string> contributors = service.GetAllContributors();
+            if (contributors.Count == 0) { Console.Error.WriteLine("조회된 기여자가 없습니다."); continue; }
 
-            var prsToCalc = cache.UserPullRequests[user]
-                .Where(p => p.IsMerged)
-                .ToList();
+            var reportData = new List<(string Id, int docIssues, int featBugIssues, int typoPrs, int docPrs, int featBugPrs, int Score)>();
 
-            var featureBugPrs = prsToCalc.Where(p => p.Labels.Contains(GitHubIssuePrLabel.Bug) || p.Labels.Contains(GitHubIssuePrLabel.Enhancement)).ToList();
-            var docPrs = prsToCalc.Where(p => p.Labels.Contains(GitHubIssuePrLabel.Documentation)).ToList();
-            var typoPrs = prsToCalc.Where(p => p.Labels.Contains(GitHubIssuePrLabel.Typo)).ToList();
-            var featureBugIssues = userClaimsToCalc.Where(c => c.Labels.Contains(GitHubIssuePrLabel.Bug) || c.Labels.Contains(GitHubIssuePrLabel.Enhancement)).ToList();
-            var docIssues = userClaimsToCalc.Where(c => c.Labels.Contains(GitHubIssuePrLabel.Documentation)).ToList();
+            foreach (var user in contributors)
+            {
+                var newClaims = service.GetClaims(user, since);
+                var newPrs = service.GetPullRequests(user, since);
 
-            int finalScore
-                = ScoreCalculator.CalculateFinalScore(featureBugPrs.Count, docPrs.Count, typoPrs.Count, featureBugIssues.Count, docIssues.Count);
+                if (!cache.UserClaims.ContainsKey(user)) cache.UserClaims[user] = new List<ClaimRecord>();
+                if (!cache.UserPullRequests.ContainsKey(user)) cache.UserPullRequests[user] = new List<PRRecord>();
 
-            reportData.Add((user, docIssues.Count, featureBugIssues.Count, typoPrs.Count, docPrs.Count, featureBugPrs.Count, finalScore));
+                foreach (var nc in newClaims)
+                {
+                    int index = cache.UserClaims[user].FindIndex(c => c.Number == nc.Number);
+                    if (index >= 0) cache.UserClaims[user][index] = nc;
+                    else cache.UserClaims[user].Add(nc);
+                }
+
+                foreach (var npr in newPrs)
+                {
+                    int index = cache.UserPullRequests[user].FindIndex(p => p.Number == npr.Number);
+                    if (index >= 0) cache.UserPullRequests[user][index] = npr;
+                    else cache.UserPullRequests[user].Add(npr);
+                }
+
+                var userClaimsToCalc = cache.UserClaims[user]
+                    .Where(c => c.ClosedReason != IssueClosedStateReason.NotPlanned && c.ClosedReason != IssueClosedStateReason.Duplicate)
+                    .ToList();
+
+                var prsToCalc = cache.UserPullRequests[user]
+                    .Where(p => p.IsMerged)
+                    .ToList();
+
+                var featureBugPrs = prsToCalc.Where(p => p.Labels.Contains(GitHubIssuePrLabel.Bug) || p.Labels.Contains(GitHubIssuePrLabel.Enhancement)).ToList();
+                var docPrs = prsToCalc.Where(p => p.Labels.Contains(GitHubIssuePrLabel.Documentation)).ToList();
+                var typoPrs = prsToCalc.Where(p => p.Labels.Contains(GitHubIssuePrLabel.Typo)).ToList();
+                var featureBugIssues = userClaimsToCalc.Where(c => c.Labels.Contains(GitHubIssuePrLabel.Bug) || c.Labels.Contains(GitHubIssuePrLabel.Enhancement)).ToList();
+                var docIssues = userClaimsToCalc.Where(c => c.Labels.Contains(GitHubIssuePrLabel.Documentation)).ToList();
+
+                int finalScore
+                    = ScoreCalculator.CalculateFinalScore(featureBugPrs.Count, docPrs.Count, typoPrs.Count, featureBugIssues.Count, docIssues.Count);
+
+                reportData.Add((user, docIssues.Count, featureBugIssues.Count, typoPrs.Count, docPrs.Count, featureBugPrs.Count, finalScore));
+            }
+
+            CacheManager.SaveCache(cachePath, cache);
+            Console.Error.WriteLine($"캐시 갱신 및 저장 완료: {cachePath}");
+
+            reportData = SortReportData(reportData, sortBy, sortOrder);
+
+            // CSV 데이터 파일 생성
+            var csv = new StringBuilder();
+            csv.AppendLine("아이디, 문서이슈, 버그/기능이슈, 오타PR, 문서PR, 버그/기능PR, 총점");
+            foreach (var r in reportData) csv.AppendLine($"{r.Id}, {r.docIssues}, {r.featBugIssues}, {r.typoPrs}, {r.docPrs}, {r.featBugPrs}, {r.Score}");
+
+            string csvPath = Path.Combine(repoOutput, "results.csv");
+            File.WriteAllText(csvPath, csv.ToString(), Encoding.UTF8);
+            Console.Error.WriteLine($"기본 데이터(CSV) 저장 완료: {csvPath}");
+
+            // txt 파일 생성
+            if (format.ToLower() == "txt")
+            {
+                string txtPath = Path.Combine(repoOutput, "results.txt");
+                string txtContent = BuildTextReport(repo, reportData);
+
+                File.WriteAllText(txtPath, txtContent, Encoding.UTF8);
+                Console.Error.WriteLine($"가독성 리포트(TXT) 추가 저장 완료: {txtPath}");
+            }
         }
-
-        CacheManager.SaveCache(cachePath, cache);
-        Console.Error.WriteLine($"캐시 갱신 및 저장 완료: {cachePath}");
-
-        reportData = SortReportData(reportData, sortBy, sortOrder);
-
-        // CSV 데이터 파일 생성
-        var csv = new StringBuilder();
-        csv.AppendLine("아이디, 문서이슈, 버그/기능이슈, 오타PR, 문서PR, 버그/기능PR, 총점");
-        foreach (var r in reportData) csv.AppendLine($"{r.Id}, {r.docIssues}, {r.featBugIssues}, {r.typoPrs}, {r.docPrs}, {r.featBugPrs}, {r.Score}");
-
-        string csvPath = Path.Combine(output, "results.csv");
-        File.WriteAllText(csvPath, csv.ToString(), Encoding.UTF8);
-        Console.Error.WriteLine($"기본 데이터(CSV) 저장 완료: {csvPath}");
-
-        // txt 파일 생성
-        if (format.ToLower() == "txt")
+        catch (Exception ex)
         {
-            string txtPath = Path.Combine(output, "results.txt");
-            string txtContent = BuildTextReport(repo, reportData);
-
-            File.WriteAllText(txtPath, txtContent, Encoding.UTF8);
-            Console.Error.WriteLine($"가독성 리포트(TXT) 추가 저장 완료: {txtPath}");
+            Console.Error.WriteLine($"데이터 처리 중 오류 발생: {ex.Message}");
         }
-    }
-    catch (Exception ex)
-    {
-        Console.Error.WriteLine($"데이터 처리 중 오류 발생: {ex.Message}");
     }
 });
 


### PR DESCRIPTION
## 관련 이슈
Closes #332

## 변경 사항
`Program.cs`의 CLI argument 구조를 단일 저장소에서 여러 저장소를 입력받을 수 있도록 변경했습니다.

### 수정 내용
- `[Argument] string repo` → `[Argument] string[] repos` 로 변경
- 옵션 기본값을 메서드 내부에서 `??=` 로 처리 (CS1737 컴파일 오류 해결)
- `foreach`로 저장소별 순차 처리
- 저장소 1개: 기존과 동일하게 `./results/` 에 저장
- 저장소 2개 이상: `./results/owner_repo/` 하위 디렉토리에 각각 저장
- 잘못된 형식 입력 시 해당 저장소만 건너뜀 (`continue`)

## 실행 예시

**단일 저장소 (기존 방식 유지)**
```bash
dotnet run -- oss2026hnu/reposcore-cs --token TOKEN
```

**여러 저장소 동시 분석**
```bash
dotnet run -- oss2026hnu/reposcore-cs oss2026hnu/reposcore-ts --token TOKEN
```

## 테스트 결과

- [x] 단일 저장소: 기존과 동일하게 `./results/results.csv` 생성 확인
- [x] 여러 저장소: `./results/oss2026hnu_reposcore-cs/results.csv`, `./results/oss2026hnu_reposcore-ts/results.csv` 각각 생성 확인
- [x] 잘못된 형식 입력 시 해당 저장소만 건너뛰고 나머지 정상 처리 확인

## 참고

이번 PR은 여러 저장소를 입력받을 수 있는 CLI 구조 마련을 목표로 합니다.
아래 항목은 별도 이슈로 분리하여 진행할 예정입니다.
- 여러 저장소 결과 합산 CSV 출력
- GraphQL alias 기반 통합 쿼리
- 캐시 구조 변경