### PR TITLE
불필요한 PadLeft 함수 삭제

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -198,8 +198,8 @@ static string BuildTextReport(
 
     sb.AppendLine(
         PadRightKorean(userHeader, userWidth) + " | " +
-        PadLeft(issuePrHeader, issuePrWidth) + " | " +
-        PadLeft(scoreHeader, scoreWidth));
+        issuePrHeader.PadLeft(issuePrWidth) + " | " +
+        scoreHeader.PadLeft(scoreWidth));
 
     sb.AppendLine(separator);
 
@@ -207,8 +207,8 @@ static string BuildTextReport(
     {
         sb.AppendLine(
             PadRightKorean(row.Id, userWidth) + " | " +
-            PadLeft(row.IssuePr, issuePrWidth) + " | " +
-            PadLeft(row.Score, scoreWidth));
+            row.IssuePr.PadLeft(issuePrWidth) + " | " +
+            row.Score.PadLeft(scoreWidth));
     }
 
     return sb.ToString();
@@ -296,11 +296,6 @@ static string BuildClaimsReport(ClaimsData data, string mode)
     }
 
     return sb.ToString();
-}
-
-static string PadLeft(string text, int width)
-{
-    return text.PadLeft(width);
 }
 
 static string PadRightKorean(string text, int width)


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #305  

### 변경사항
불필요한 PadLeft 함수 삭제
PadLeft(string text, int width);
위 함수를 쓰는 코드들을 text.PadLeft(width); 이 코드로 변경

### 🧪 테스트 방법 (선택 사항)
프로그램 실행 후 출력 정렬 및 결과가 정상 동작하는지 확인

### 💬 참고 사항 (선택 사항)