### PR TITLE
dotnet-guide.md 절 번호 오류 수정

### DIFF
--- a/docs/dotnet-guide.md
+++ b/docs/dotnet-guide.md
@@ -372,7 +372,7 @@ dotnet test RepoScore.Tests/RepoScore.Tests.csproj
 
 ---
 
-### 7.7 정리
+### 7.6 정리
 
 기본 흐름은 다음과 같습니다.
 


### PR DESCRIPTION
### ISSUE_ID
해당 PR은 단순히 절 번호 표기 오타 수정으로, 별도의 이슈 없이 직접 PR 드립니다.

### 변경사항
기존 dotnet-guide.md 문서에서 절 번호가 7.5 다음에 7.7로 이어지는 오류가 있어,  
이를 7.6으로 오타를 수정하여 문서 흐름을 바로잡았습니다.

### 🧪 테스트 방법 (선택 사항)
없음

### 💬 참고 사항 (선택 사항)
없음
