### PR TITLE
docs/cli-options-guide.md에서 --claims 입력방식 정의 정리 #353

### DIFF
--- a/docs/cli-options-guide.md
+++ b/docs/cli-options-guide.md
@@ -125,8 +125,7 @@ dotnet run -- oss2026hnu/reposcore-cs --claims=issue --token ghp_xxxxx
 dotnet run -- oss2026hnu/reposcore-cs --claims=user --token ghp_xxxxx
 ```
 
-> ⚠️ `--claims`는 `=` 없이 값을 공백으로 구분해서 입력하면 동작이 다를 수 있습니다.  
-> `--claims=issue` 또는 `--claims issue` 형식 모두 사용 가능합니다.
+> ⚠️  `--claims=issue` 또는 `--claims issue` 형식 모두 사용 가능합니다.
 
 ---
 


### PR DESCRIPTION
### ISSUE_ID
Closes https://github.com/oss2026hnu/reposcore-cs/issues/353#issue-4356885325

### 변경사항
- [x] --claims=issue와 --claims issue 옵션 방식 동일함을 확인함. 따라서 "--claims는 = 없이 값을 공백으로 구분해서 입력하면 동작이 다를 수 있습니다." 부분을 삭제함. 

### 🧪 테스트 방법 (선택 사항)

### 💬 참고 사항 (선택 사항)
