### PR TITLE
CacheManager, GitHubService, Program에 설명 주석 추가

### DIFF
--- a/Data/CacheManager.cs
+++ b/Data/CacheManager.cs
@@ -7,7 +7,7 @@ using RepoScore.Services;
 
 namespace RepoScore.Data
 {
-
+    // 저장소별 분석 캐시 데이터를 표현하는 클래스. JSON 파일로 직렬화되어 저장됨.
     public class RepoCache
     {
         public string Repository { get; set; } = string.Empty;
@@ -20,6 +20,8 @@ namespace RepoScore.Data
         public Dictionary<string, List<PRRecord>> UserPullRequests { get; set; } = new();
     }
 
+    // 캐시 파일의 로드 및 저장을 담당하는 클래스.
+    // 이전 분석 결과를 JSON 파일로 유지하여 불필요한 API 요청을 줄임.
     public static class CacheManager
     {
         private static readonly JsonSerializerOptions s_jsonOptions = new JsonSerializerOptions
@@ -28,6 +30,8 @@ namespace RepoScore.Data
             Converters = { new JsonStringEnumConverter() }
         };
 
+        // 기존 캐시 파일을 읽어 RepoCache 객체를 반환.
+        // 파일이 없거나 손상된 경우, 또는 noCache=true이면 빈 캐시를 반환.
         public static RepoCache LoadCache(string cacheFilePath, string repoName, bool noCache = false)
         {
             if (noCache)
@@ -58,6 +62,8 @@ namespace RepoScore.Data
                 return new RepoCache { Repository = repoName };
             }
         }
+
+        // 분석 결과 캐시를 JSON 파일로 저장. 저장 시각과 키워드를 함께 기록.
         public static void SaveCache(string cacheFilePath, RepoCache cacheData, string[]? keywords)
         {
             var dir = Path.GetDirectoryName(cacheFilePath);
@@ -72,6 +78,9 @@ namespace RepoScore.Data
             string json = JsonSerializer.Serialize(cacheData, s_jsonOptions);
             File.WriteAllText(cacheFilePath, json);
         }
+
+        // 캐시에 저장된 키워드와 현재 실행 키워드가 동일한지 비교.
+        // 키워드가 달라진 경우 캐시 무효화 여부 판단에 사용됨.
         public static bool HasSameKeywords(RepoCache cacheData, string[]? currentKeywords)
         {
             var cachedKeywords = cacheData.Keywords;

--- a/Program.cs
+++ b/Program.cs
@@ -178,6 +178,7 @@ var cache = CacheManager.LoadCache(cachePath, repo, noCache);
     }
 });
 
+// 분석 결과 목록을 지정된 기준(score | id)과 방향(asc | desc)으로 정렬하여 반환.
 static List<(string Id, int docIssues, int featBugIssues, int typoPrs, int docPrs, int featBugPrs, int Score)>
 SortReportData(List<(string Id, int docIssues, int featBugIssues, int typoPrs, int docPrs, int featBugPrs, int Score)> data,
                 string sortBy, string sortOrder)
@@ -221,6 +222,7 @@ static void PrintSpectreTable(string repo, List<(string Id, int docIssues, int f
     AnsiConsole.Write(table);
 }
 
+// 분석 결과를 ANSI 코드 없는 순수 텍스트 테이블로 생성. 파일 저장용.
 static string BuildTextReport(
     string repo,
     List<(string Id, int docIssues, int featBugIssues, int typoPrs, int docPrs, int featBugPrs, int Score)> reportData)
@@ -250,6 +252,8 @@ static string BuildTextReport(
     return recorder.ExportText();
 }
 
+// 이슈 선점 현황을 mode에 따라 문자열 리포트로 생성.
+// mode="user"이면 유저별, 그 외("issue")이면 이슈 번호 오름차순으로 출력.
 static string BuildClaimsReport(ClaimsData data, string mode)
 {
     var sb = new StringBuilder();
@@ -309,6 +313,7 @@ static string BuildClaimsReport(ClaimsData data, string mode)
     return sb.ToString();
 }
 
+// 선점 기한까지 남은 시간을 HH:MM:SS 형식으로 반환. 기한 초과 시 "기한 초과" 반환.
 static string FormatRemainingTime(TimeSpan remaining)
 {
     if (remaining <= TimeSpan.Zero) return "   기한 초과";

--- a/Services/GitHubService.cs
+++ b/Services/GitHubService.cs
@@ -50,6 +50,8 @@ namespace RepoScore.Services
         public DateTimeOffset UpdatedAt { get; set; }
     }
 
+    // GitHub REST/GraphQL API를 통해 저장소 데이터를 조회하는 서비스 클래스.
+    // PR 조회, 이슈 조회, 기여자 목록 조회, 이슈 선점 현황 조회 기능을 담당.
     public class GitHubService
     {
         private readonly Octokit.GraphQL.Connection _graphQLConnection;
@@ -77,6 +79,8 @@ namespace RepoScore.Services
             };
         }
 
+        // 특정 사용자가 작성하고 머지된 PR 목록을 GraphQL로 조회.
+        // since가 지정된 경우 해당 시각 이후 업데이트된 PR만 가져옴.
         public List<PRRecord> GetPullRequests(string authorLogin, DateTimeOffset? since = null)
         {
             string searchString = $"repo:{_owner}/{_repo} is:pr is:merged author:{authorLogin}";
@@ -130,6 +134,9 @@ namespace RepoScore.Services
             return prRecords;
         }
 
+        // 특정 사용자가 작성한 이슈 목록을 GraphQL로 조회.
+        // "not planned", "duplicate" 사유로 닫힌 이슈는 제외.
+        // since가 지정된 경우 해당 시각 이후 업데이트된 이슈만 가져옴.
         public List<ClaimRecord> GetClaims(string authorLogin, DateTimeOffset? since = null)
         {
             const string rawGraphQl = @"
@@ -225,6 +232,8 @@ namespace RepoScore.Services
             return claimRecords;
         }
 
+        // 저장소의 열린 이슈를 대상으로 최근 48시간 내 선점 현황을 조회.
+        // 이슈별로 선점 댓글 작성자, 남은 기한, 연결된 PR 유무를 파악하여 반환.
         public ClaimsData GetRecentClaimsData()
         {
             var claimsData = new ClaimsData();
@@ -338,6 +347,8 @@ namespace RepoScore.Services
             return issueLabels.Contains(GitHubIssuePrLabel.Documentation) || issueLabels.Contains(GitHubIssuePrLabel.Typo);
         }
 
+        // GitHub 라벨 이름 문자열을 GitHubIssuePrLabel 열거형 값으로 변환.
+        // 대소문자 및 공백/하이픈을 정규화한 뒤 매핑. 알 수 없는 라벨은 None 반환.
         private static GitHubIssuePrLabel ParseGitHubLabel(string labelName)
         {
             if (string.IsNullOrEmpty(labelName)) return GitHubIssuePrLabel.None;
@@ -369,6 +380,7 @@ namespace RepoScore.Services
             });
         }
 
+        // GraphQL 응답의 이슈 노드에서 닫힌 사유(stateReason)를 파싱하여 열거형으로 반환.
         private static IssueClosedStateReason ParseIssueClosedStateReason(JsonElement issueNode)
         {
             if (!issueNode.TryGetProperty("stateReason", out var stateReasonElement) ||
@@ -387,6 +399,8 @@ namespace RepoScore.Services
             };
         }
 
+        // REST API를 통해 저장소의 전체 기여자 로그인 ID 목록을 조회.
+        // 조회 실패 시 빈 목록을 반환.
         public List<string> GetAllContributors()
         {
             try


### PR DESCRIPTION
### ISSUE_ID
Closes #329 

### 변경사항
- [ ] `CacheManager.cs` — `RepoCache`, `CacheManager` 클래스 및 `LoadCache`, `SaveCache`, `HasSameKeywords` 메서드에 설명 주석 추가
- [ ] `GitHubService.cs` — `GitHubService` 클래스 및 `GetPullRequests`, `GetClaims`, `GetRecentClaimsData`, `GetAllContributors`, `ParseGitHubLabel`, `ParseIssueClosedStateReason` 메서드에 설명 주석 추가
- [ ] `Program.cs` — `SortReportData`, `BuildTextReport`, `BuildClaimsReport`, `FormatRemainingTime` helper 함수에 설명 주석 추가

### 💬 참고 사항