### PR TITLE
fix: -f txt 옵션 사용 시 터미널 중복 출력 제거

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -156,16 +156,13 @@ CoconaApp.Run((
             File.WriteAllText(csvPath, csv.ToString(), Encoding.UTF8);
             Console.Error.WriteLine($"기본 데이터(CSV) 저장 완료: {csvPath}");
 
-            // TXT 리포트 생성 및 화면 출력
+            // TXT 리포트 생성
             if (format.ToLower() == "txt")
             {
                 string txtPath = Path.Combine(repoOutput, "results.txt");
                 string txtContent = ReportFormatter.BuildTextReport(repo, reportData);
-
                 File.WriteAllText(txtPath, txtContent, Encoding.UTF8);
                 Console.Error.WriteLine($"가독성 리포트(TXT) 추가 저장 완료: {txtPath}");
-
-                PrintSpectreTable(repo, reportData);
             }
         }
         catch (Exception ex)
@@ -174,26 +171,3 @@ CoconaApp.Run((
         }
     }
 });
-
-// Spectre.Console을 사용하여 터미널에 직접 출력하는 함수
-static void PrintSpectreTable(string repo, List<(string Id, int docIssues, int featBugIssues, int typoPrs, int docPrs, int featBugPrs, int Score)> reportData)
-{
-    var table = new Table();
-    table.Title($"[bold blue]=== {repo} 기여도 리포트 ===[/]");
-    table.Border(TableBorder.Rounded);
-
-    table.AddColumn(new TableColumn("[yellow]유저[/]").Centered());
-    table.AddColumn(new TableColumn("[yellow]이슈/PR[/]").Centered());
-    table.AddColumn(new TableColumn("[yellow]점수[/]").Centered());
-
-    foreach (var r in reportData)
-    {
-        table.AddRow(
-            r.Id,
-            $"{r.docIssues + r.featBugIssues}/{r.typoPrs + r.docPrs + r.featBugPrs}",
-            $"[green]{r.Score}[/]"
-        );
-    }
-
-    AnsiConsole.Write(table);
-}


### PR DESCRIPTION
## 관련 이슈
Closes #358

## 변경 사항
`-f txt` 옵션 사용 시 터미널에 결과가 중복 출력되는 문제를 수정했습니다.

### 수정 내용
- `PrintSpectreTable()` 호출 제거
- `PrintSpectreTable()` 함수 정의 제거
- csv, txt 모두 파일 저장만 수행, 터미널 출력 없음
- 불필요한 주석 정리

## 테스트 결과
- [x] `-f csv`: 터미널 출력 없이 `results.csv` 저장 확인
- [x] `-f txt`: 터미널 출력 없이 `results.csv` + `results.txt` 저장 확인