### PR TITLE
프로젝트 코드 내 이슈 도메인 네이밍 명확화 및 변수명 개선

### DIFF
--- a/Data/CacheManager.cs
+++ b/Data/CacheManager.cs
@@ -15,7 +15,7 @@ namespace RepoScore.Data
 
         public string[]? Keywords { get; set; }
 
-        public Dictionary<string, List<ClaimRecord>> UserClaims { get; set; } = new();
+        public Dictionary<string, List<IssueRecord>> UserIssues { get; set; } = new();
 
         public Dictionary<string, List<PRRecord>> UserPullRequests { get; set; } = new();
     }

--- a/Program.cs
+++ b/Program.cs
@@ -107,17 +107,17 @@ CoconaApp.Run((
 
             foreach (var user in contributors)
             {
-                var newClaims = service.GetClaims(user, since);
+                var newIssues = service.GetIssues(user, since);
                 var newPrs = service.GetPullRequests(user, since);
 
-                if (!cache.UserClaims.ContainsKey(user)) cache.UserClaims[user] = new List<ClaimRecord>();
+                if (!cache.UserIssues.ContainsKey(user)) cache.UserIssues[user] = new List<IssueRecord>();
                 if (!cache.UserPullRequests.ContainsKey(user)) cache.UserPullRequests[user] = new List<PRRecord>();
 
-                foreach (var nc in newClaims)
+                foreach (var ni in newIssues)
                 {
-                    int index = cache.UserClaims[user].FindIndex(c => c.Number == nc.Number);
-                    if (index >= 0) cache.UserClaims[user][index] = nc;
-                    else cache.UserClaims[user].Add(nc);
+                    int index = cache.UserIssues[user].FindIndex(c => c.Number == ni.Number);
+                    if (index >= 0) cache.UserIssues[user][index] = ni;
+                    else cache.UserIssues[user].Add(ni);
                 }
 
                 foreach (var npr in newPrs)
@@ -127,14 +127,14 @@ CoconaApp.Run((
                     else cache.UserPullRequests[user].Add(npr);
                 }
 
-                var userClaimsToCalc = cache.UserClaims[user];
+                var userIssuesToCalc = cache.UserIssues[user];
                 var prsToCalc = cache.UserPullRequests[user];
 
                 var featureBugPrs = prsToCalc.Where(p => p.Labels.Contains(GitHubIssuePrLabel.Bug) || p.Labels.Contains(GitHubIssuePrLabel.Enhancement)).ToList();
                 var docPrs = prsToCalc.Where(p => p.Labels.Contains(GitHubIssuePrLabel.Documentation)).ToList();
                 var typoPrs = prsToCalc.Where(p => p.Labels.Contains(GitHubIssuePrLabel.Typo)).ToList();
-                var featureBugIssues = userClaimsToCalc.Where(c => c.Labels.Contains(GitHubIssuePrLabel.Bug) || c.Labels.Contains(GitHubIssuePrLabel.Enhancement)).ToList();
-                var docIssues = userClaimsToCalc.Where(c => c.Labels.Contains(GitHubIssuePrLabel.Documentation)).ToList();
+                var featureBugIssues = userIssuesToCalc.Where(c => c.Labels.Contains(GitHubIssuePrLabel.Bug) || c.Labels.Contains(GitHubIssuePrLabel.Enhancement)).ToList();
+                var docIssues = userIssuesToCalc.Where(c => c.Labels.Contains(GitHubIssuePrLabel.Documentation)).ToList();
 
                 int finalScore
                     = ScoreCalculator.CalculateFinalScore(featureBugPrs.Count, docPrs.Count, typoPrs.Count, featureBugIssues.Count, docIssues.Count);

--- a/RepoScore.Tests/CacheManagerTests.cs
+++ b/RepoScore.Tests/CacheManagerTests.cs
@@ -16,7 +16,7 @@ public class CacheManagerTests
 
         Assert.Equal("owner/repo", cache.Repository);
         Assert.Equal(DateTimeOffset.MinValue, cache.LastAnalyzedAt);
-        Assert.Empty(cache.UserClaims);
+        Assert.Empty(cache.UserIssues);
         Assert.Empty(cache.UserPullRequests);
     }
 
@@ -29,11 +29,11 @@ public class CacheManagerTests
         var cache = new RepoCache
         {
             Repository = "owner/repo",
-            UserClaims =
+            UserIssues =
             {
-                ["user1"] = new List<ClaimRecord>
+                ["user1"] = new List<IssueRecord>
                 {
-                    new ClaimRecord
+                    new IssueRecord
                     {
                         Number = 333,
                         Url = "https://github.com/oss2026hnu/reposcore-cs/issues/333",
@@ -72,9 +72,9 @@ public class CacheManagerTests
         Assert.True(loadedCache.LastAnalyzedAt > DateTimeOffset.MinValue);
         Assert.True(CacheManager.HasSameKeywords(loadedCache, new[] { "할게요", "제가 하겠습니다" }));
 
-        Assert.Single(loadedCache.UserClaims["user1"]);
-        Assert.Equal(333, loadedCache.UserClaims["user1"][0].Number);
-        Assert.Contains(GitHubIssuePrLabel.Enhancement, loadedCache.UserClaims["user1"][0].Labels);
+        Assert.Single(loadedCache.UserIssues["user1"]);
+        Assert.Equal(333, loadedCache.UserIssues["user1"][0].Number);
+        Assert.Contains(GitHubIssuePrLabel.Enhancement, loadedCache.UserIssues["user1"][0].Labels);
 
         Assert.Single(loadedCache.UserPullRequests["user1"]);
         Assert.Equal(400, loadedCache.UserPullRequests["user1"][0].Number);
@@ -99,7 +99,7 @@ public class CacheManagerTests
 
         Assert.Equal("owner/new-repo", loadedCache.Repository);
         Assert.Equal(DateTimeOffset.MinValue, loadedCache.LastAnalyzedAt);
-        Assert.Empty(loadedCache.UserClaims);
+        Assert.Empty(loadedCache.UserIssues);
         Assert.Empty(loadedCache.UserPullRequests);
     }
 

--- a/Services/GitHubService.cs
+++ b/Services/GitHubService.cs
@@ -22,7 +22,7 @@ namespace RepoScore.Services
         NotPlanned
     }
 
-    public class ClaimRecord
+    public class IssueRecord
     {
         public int Number { get; set; }
         public string Url { get; set; } = string.Empty;
@@ -36,7 +36,7 @@ namespace RepoScore.Services
 
     public class ClaimsData
     {
-        public Dictionary<string, List<ClaimRecord>> ClaimedMap { get; set; } = new();
+        public Dictionary<string, List<IssueRecord>> ClaimedMap { get; set; } = new();
         public List<string> UnclaimedUrls { get; set; } = new();
     }
 
@@ -137,7 +137,7 @@ namespace RepoScore.Services
         // 특정 사용자가 작성한 이슈 목록을 GraphQL로 조회.
         // "not planned", "duplicate" 사유로 닫힌 이슈는 제외.
         // since가 지정된 경우 해당 시각 이후 업데이트된 이슈만 가져옴.
-        public List<ClaimRecord> GetClaims(string authorLogin, DateTimeOffset? since = null)
+        public List<IssueRecord> GetIssues(string authorLogin, DateTimeOffset? since = null)
         {
             const string rawGraphQl = @"
             query($searchQuery: String!, $after: String) {
@@ -169,7 +169,7 @@ namespace RepoScore.Services
                 searchString += $" updated:>={since.Value.ToUniversalTime():yyyy-MM-ddTHH:mm:ssZ}";
             }
 
-            var claimRecords = new List<ClaimRecord>();
+            var issueRecords = new List<IssueRecord>();
             string? cursor = null;
             bool hasNextPage = true;
 
@@ -216,7 +216,7 @@ namespace RepoScore.Services
                         var updatedAt = node.TryGetProperty("updatedAt", out var updatedElement)
                             ? DateTimeOffset.Parse(updatedElement.GetString()!) : DateTimeOffset.MinValue;
 
-                        claimRecords.Add(new ClaimRecord
+                        issueRecords.Add(new IssueRecord
                         {
                             Number = node.TryGetProperty("number", out var numEl) ? numEl.GetInt32() : 0,
                             Title = node.TryGetProperty("title", out var titEl) ? titEl.GetString() ?? "" : "",
@@ -229,7 +229,7 @@ namespace RepoScore.Services
                 }
             }
 
-            return claimRecords;
+            return issueRecords;
         }
 
         // 저장소의 열린 이슈를 대상으로 최근 48시간 내 선점 현황을 조회.
@@ -284,9 +284,9 @@ namespace RepoScore.Services
                             var hasPr = issue.Number > 0 && HasLinkedPullRequest(issue.Number);
 
                             if (!claimsData.ClaimedMap.ContainsKey(login))
-                                claimsData.ClaimedMap[login] = new List<ClaimRecord>();
+                                claimsData.ClaimedMap[login] = new List<IssueRecord>();
 
-                            claimsData.ClaimedMap[login].Add(new ClaimRecord
+                            claimsData.ClaimedMap[login].Add(new IssueRecord
                             {
                                 Number = issue.Number,
                                 Url = issue.Url,


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #367

### 변경사항
1. 테스트 코드(CacheManagerTests) 및 캐시 구조(RepoCache)에 맞게 연관 코드 수정
2. ClaimRecord → IssueRecord, GetClaims → GetIssues 등 클래스 및 메서드명 수정
3. UserClaims → UserIssues 등 변수명 일괄 변경 (Program, CacheManager, Tests 포함)
4. Claim 기반 네이밍을 Issue 기반으로 변경하여 도메인 명확히 개선

### 🧪 테스트 방법 (선택 사항)
- dotnet build reposcore-cs.csproj 실행 
- dotnet build RepoScore.Tests/RepoScore.Tests.csproj 실행 
- dotnet test RepoScore.Tests/RepoScore.Tests.csproj 실행
최종적으로 전체 빌드 성공 확인, 테스트 36개 모두 통과 확인

### 💬 참고 사항 (선택 사항)
없음
