### PR TITLE
여러 저장소 기여도 통합 집계 기능

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -37,6 +37,10 @@ CoconaApp.Run((
         ? keywords.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
         : null;
 
+    // 전체 저장소 합산용 딕셔너리: 유저별 누적 기여 데이터
+    var totalUserIssues = new Dictionary<string, List<IssueRecord>>();
+    var totalUserPullRequests = new Dictionary<string, List<PRRecord>>();
+
     foreach (var repo in repos)
     {
         var parts = repo.Split('/');
@@ -135,6 +139,25 @@ CoconaApp.Run((
                     = ScoreCalculator.CalculateFinalScore(featureBugPrs.Count, docPrs.Count, typoPrs.Count, featureBugIssues.Count, docIssues.Count);
 
                 reportData.Add((user, docIssues.Count, featureBugIssues.Count, typoPrs.Count, docPrs.Count, featureBugPrs.Count, finalScore));
+
+                // 전체 합산용 누적
+                if (repos.Length > 1)
+                {
+                    if (!totalUserIssues.ContainsKey(user)) totalUserIssues[user] = new List<IssueRecord>();
+                    if (!totalUserPullRequests.ContainsKey(user)) totalUserPullRequests[user] = new List<PRRecord>();
+
+                    // 저장소별 이슈/PR은 번호가 겹칠 수 있으므로 URL 기준으로 중복 방지
+                    foreach (var issue in cache.UserIssues[user])
+                    {
+                        if (!totalUserIssues[user].Any(i => i.Url == issue.Url))
+                            totalUserIssues[user].Add(issue);
+                    }
+                    foreach (var pr in cache.UserPullRequests[user])
+                    {
+                        if (!totalUserPullRequests[user].Any(p => p.Url == pr.Url))
+                            totalUserPullRequests[user].Add(pr);
+                    }
+                }
             }
 
             CacheManager.SaveCache(cachePath, cache, parsedKeywords);
@@ -158,6 +181,63 @@ CoconaApp.Run((
                 string txtContent = ReportFormatter.BuildTextReport(repo, reportData);
                 File.WriteAllText(txtPath, txtContent, Encoding.UTF8);
                 Console.Error.WriteLine($"가독성 리포트(TXT) 추가 저장 완료: {txtPath}");
+            }
+        }
+        catch (Exception ex)
+        {
+            AnsiConsole.WriteException(ex);
+        }
+    }
+
+    // 저장소가 2개 이상이고 claims 모드가 아닐 때만 전체 합산 리포트 생성
+    if (repos.Length > 1 && claims == null && totalUserIssues.Count > 0)
+    {
+        try
+        {
+            AnsiConsole.MarkupLine($"\n[green]전체 저장소 합산 리포트 생성 중...[/]");
+
+            var totalReportData = new List<(string Id, int docIssues, int featBugIssues, int typoPrs, int docPrs, int featBugPrs, int Score)>();
+
+            var allUsers = totalUserIssues.Keys.Union(totalUserPullRequests.Keys).ToList();
+
+            foreach (var user in allUsers)
+            {
+                var allIssues = totalUserIssues.TryGetValue(user, out var issues) ? issues : new List<IssueRecord>();
+                var allPrs = totalUserPullRequests.TryGetValue(user, out var prs) ? prs : new List<PRRecord>();
+
+                var featureBugPrs = allPrs.Where(p => p.Labels.Contains(GitHubIssuePrLabel.Bug) || p.Labels.Contains(GitHubIssuePrLabel.Enhancement)).ToList();
+                var docPrs = allPrs.Where(p => p.Labels.Contains(GitHubIssuePrLabel.Documentation)).ToList();
+                var typoPrs = allPrs.Where(p => p.Labels.Contains(GitHubIssuePrLabel.Typo)).ToList();
+                var featureBugIssues = allIssues.Where(c => c.Labels.Contains(GitHubIssuePrLabel.Bug) || c.Labels.Contains(GitHubIssuePrLabel.Enhancement)).ToList();
+                var docIssues = allIssues.Where(c => c.Labels.Contains(GitHubIssuePrLabel.Documentation)).ToList();
+
+                int finalScore = ScoreCalculator.CalculateFinalScore(featureBugPrs.Count, docPrs.Count, typoPrs.Count, featureBugIssues.Count, docIssues.Count);
+
+                totalReportData.Add((user, docIssues.Count, featureBugIssues.Count, typoPrs.Count, docPrs.Count, featureBugPrs.Count, finalScore));
+            }
+
+            totalReportData = ReportSorter.SortReportData(totalReportData, sortBy, sortOrder);
+
+            string totalOutput = output;
+            if (!Directory.Exists(totalOutput)) Directory.CreateDirectory(totalOutput);
+
+            // 합산 CSV
+            var totalCsv = new StringBuilder();
+            totalCsv.AppendLine("아이디, 문서이슈, 버그/기능이슈, 오타PR, 문서PR, 버그/기능PR, 총점");
+            foreach (var r in totalReportData) totalCsv.AppendLine($"{r.Id}, {r.docIssues}, {r.featBugIssues}, {r.typoPrs}, {r.docPrs}, {r.featBugPrs}, {r.Score}");
+
+            string totalCsvPath = Path.Combine(totalOutput, "results.csv");
+            File.WriteAllText(totalCsvPath, totalCsv.ToString(), Encoding.UTF8);
+            Console.Error.WriteLine($"전체 합산 데이터(CSV) 저장 완료: {totalCsvPath}");
+
+            // 합산 TXT
+            if (format.ToLower() == "txt")
+            {
+                string totalLabel = string.Join(" + ", repos);
+                string totalTxtPath = Path.Combine(totalOutput, "results.txt");
+                string totalTxtContent = ReportFormatter.BuildTextReport(totalLabel, totalReportData);
+                File.WriteAllText(totalTxtPath, totalTxtContent, Encoding.UTF8);
+                Console.Error.WriteLine($"전체 합산 리포트(TXT) 저장 완료: {totalTxtPath}");
             }
         }
         catch (Exception ex)

--- a/Program.cs
+++ b/Program.cs
@@ -147,14 +147,21 @@ CoconaApp.Run((
                     if (!totalUserPullRequests.ContainsKey(user)) totalUserPullRequests[user] = new List<PRRecord>();
 
                     // 저장소별 이슈/PR은 번호가 겹칠 수 있으므로 URL 기준으로 중복 방지
+                    // URL이 비어있는 경우를 대비해 URL이 있으면 URL로, 없으면 Number 기준으로 판별
                     foreach (var issue in cache.UserIssues[user])
                     {
-                        if (!totalUserIssues[user].Any(i => i.Url == issue.Url))
+                        bool isDuplicate = string.IsNullOrEmpty(issue.Url)
+                            ? totalUserIssues[user].Any(i => string.IsNullOrEmpty(i.Url) && i.Number == issue.Number)
+                            : totalUserIssues[user].Any(i => i.Url == issue.Url);
+                        if (!isDuplicate)
                             totalUserIssues[user].Add(issue);
                     }
                     foreach (var pr in cache.UserPullRequests[user])
                     {
-                        if (!totalUserPullRequests[user].Any(p => p.Url == pr.Url))
+                        bool isDuplicate = string.IsNullOrEmpty(pr.Url)
+                            ? totalUserPullRequests[user].Any(p => string.IsNullOrEmpty(p.Url) && p.Number == pr.Number)
+                            : totalUserPullRequests[user].Any(p => p.Url == pr.Url);
+                        if (!isDuplicate)
                             totalUserPullRequests[user].Add(pr);
                     }
                 }

--- a/Program.cs
+++ b/Program.cs
@@ -190,7 +190,7 @@ CoconaApp.Run((
     }
 
     // 저장소가 2개 이상이고 claims 모드가 아닐 때만 전체 합산 리포트 생성
-    if (repos.Length > 1 && claims == null && totalUserIssues.Count > 0)
+    if (repos.Length > 1 && claims == null && (totalUserIssues.Count > 0 || totalUserPullRequests.Count > 0))
     {
         try
         {


### PR DESCRIPTION
### ISSUE_ID
Closes #365 

### 변경사항
- [x] 여러 저장소 분석 시 유저별 기여 데이터를 URL 기준으로 전체 합산
- [x] 합산된 데이터를 바탕으로 `ScoreCalculator.CalculateFinalScore` 단 한 번 호출하여 총점 산출
- [x] 전체 합산 결과를 `{output}/results.csv` (및 `--format txt` 시 `results.txt`)로 저장
- [x] 저장소별 개별 리포트(`{output}/{owner}_{repo}/`) 생성 기능은 기존과 동일하게 유지

### 🧪 테스트 방법
```bash
# 저장소 2개 입력 시 합산 리포트 생성 확인
dotnet run -- oss2026hnu/reposcore-cs oss2026hnu/reposcore-ts --token $GITHUB_TOKEN

# 예상 출력 파일 구조
# results/oss2026hnu_reposcore-cs/results.csv  ← 개별
# results/oss2026hnu_reposcore-ts/results.csv  ← 개별
# results/results.csv                          ← 전체 합산 (신규)

# 저장소 1개 시 기존 동작과 동일한지 확인
dotnet run -- oss2026hnu/reposcore-cs --token $GITHUB_TOKEN
```

### 💬 참고 사항
- 저장소가 1개인 경우 합산 리포트는 생성되지 않습니다.
- 이슈/PR 번호는 저장소마다 독립적으로 부여되므로 중복 판별은 URL 기준으로 처리하며, URL이 비어있는 경우 Number를 보조 기준으로 사용합니다.
- `--claims` 모드에서는 합산 리포트를 생성하지 않습니다.