### PR TITLE
docs validation 워크플로우 분리

### DIFF
--- a/.github/workflows/docs-readme-validation.yml
+++ b/.github/workflows/docs-readme-validation.yml
@@ -1,0 +1,34 @@
+name: Docs README Validation
+
+on:
+  pull_request:
+    paths:
+      - "docs/**"
+      - "tools/update-readme.py"
+      - "Makefile"
+
+jobs:
+  verify-docs-readme:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Run docs README generation
+        env:
+          LANG: ko_KR.UTF-8
+          LC_ALL: ko_KR.UTF-8
+        run: make docs
+
+      - name: Verify docs/README.md is up to date
+        run: |
+          if ! git diff --exit-code -- docs/README.md; then
+            echo "::error::docs/README.md is out of sync. Please run 'make docs' locally and commit the changes."
+            exit 1
+          fi

--- a/.github/workflows/docs-synopsis-validation.yml
+++ b/.github/workflows/docs-synopsis-validation.yml
@@ -1,17 +1,16 @@
-name: Docs Validation
+name: Docs Synopsis Validation
 
 on:
   pull_request:
     paths:
-      - "docs/**"
-      - "tools/update-readme.py"
       - "tools/update-synopsis.py"
       - "Program.cs"
       - "reposcore-cs.csproj"
       - "Makefile"
+      - "README.md"
 
 jobs:
-  verify-docs:
+  verify-docs-synopsis:
     runs-on: ubuntu-latest
 
     steps:
@@ -28,15 +27,15 @@ jobs:
         with:
           dotnet-version: "10.0.x"
 
-      - name: Run make 
+      - name: Run full README generation
         env:
           LANG: ko_KR.UTF-8
           LC_ALL: ko_KR.UTF-8
         run: make
 
-      - name: Verify no changes in README files
+      - name: Verify README.md synopsis is up to date
         run: |
-          if ! git diff --exit-code; then
-            echo "::error::README files are out of sync. Please run 'make' locally and commit the changes."
+          if ! git diff --exit-code -- README.md; then
+            echo "::error::README.md synopsis is out of sync. Please run 'make' locally and commit the changes."
             exit 1
           fi


### PR DESCRIPTION
### ISSUE_ID
Closes #375

### 변경사항
docs/README.md 검증 전용 docs-readme-validation.yml 워크플로우 추가
최상위 README.md synopsis 검증 전용 docs-synopsis-validation.yml 워크플로우 추가
기존 docs-validation.yml 워크플로우를 제거

docs README 검증은 Python 기반으로만 동작하도록 분리
synopsis 검증은 .NET SDK 설정 후 make 전체 실행을 통해 검증하도록 분리

### 🧪 테스트 방법 (선택 사항)
python3 tools/update-readme.py 실행 후 git diff -- docs/README.md를 통해 docs/README.md 추가 변경 사항이 없는 것을 확인
make 실행 후 git diff -- README.md를 통해 README.md synopsis 구간 추가 변경 사항이 없는 것을 확인

### 💬 참고 사항 (선택 사항)
없음
