### PR TITLE
이슈조회와 이슈와 연결된 PR 조회 쿼리 통합 

### DIFF
--- a/Services/GitHubService.cs
+++ b/Services/GitHubService.cs
@@ -250,6 +250,15 @@ namespace RepoScore.Services
                             issue.Number,
                             issue.Url,
 
+                            ConnectedPRStates = issue.TimelineItems(null, null, 10, null, null, null)
+                                .Nodes.Select(node => node.Switch<string>(item =>
+                                    item.CrossReferencedEvent(cross => 
+                                        cross.Source.Switch<string>(src => 
+                                            src.PullRequest(pr => pr.State.ToString()) // State를 문자열로 변환
+                                        )
+                                    )
+                                )).ToList(),
+
                             Labels = issue.Labels(10, null, null, null, null).Nodes.Select(l => l.Name).ToList(),
                             Comments = issue.Comments(10, null, null, null, null).Nodes.Select(c => new
                             {
@@ -277,7 +286,8 @@ namespace RepoScore.Services
                         {
                             var deadlineHours = IsDocumentTask(issueLabels) ? 24.0 : 48.0;
                             var remaining = comment.CreatedAt.AddHours(deadlineHours) - now;
-                            var hasPr = issue.Number > 0 && HasLinkedPullRequest(issue.Number);
+                            var hasPr = issue.ConnectedPRStates
+                                .Any(state => state == "Open" || state == "Merged");
 
                             if (!claimsData.ClaimedMap.ContainsKey(login))
                                 claimsData.ClaimedMap[login] = new List<IssueRecord>();
@@ -314,28 +324,6 @@ namespace RepoScore.Services
                 .Nodes.Select(c => c.Body);
 
             return _graphQLConnection.Run(query).Result.ToList();
-        }
-
-        private bool HasLinkedPullRequest(int issueNumber)
-        {
-            try
-            {
-                var query = new Octokit.GraphQL.Query()
-                    .Repository(_repo, _owner)
-                    .Issue(issueNumber)
-                    .TimelineItems(first: 50)
-                    .Nodes
-                    .OfType<CrossReferencedEvent>()
-                    .Select(e => e.Url);
-
-                var timelineUrls = _graphQLConnection.Run(query).Result;
-
-                return timelineUrls.Any(url => !string.IsNullOrEmpty(url) && url.Contains("/pull/"));
-            }
-            catch
-            {
-                return false;
-            }
         }
 
         internal static bool IsDocumentTask(List<GitHubIssuePrLabel> issueLabels)


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #382

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- [ ] GithubService.cs 파일에서 HasLinkedPullRequest 메소드 삭제
- [ ] GetRecentClaimsData 호출시 이슈와 연결된 PR도 함께 조회하도록 수정


### 🧪 테스트 방법 (선택 사항)
dotnet run -- oss2026hnu/reposcore-cs oss2026hnu/reposcore-ts --token {토큰} --claims=

위 명령어를 실행하여 정상 동작 확인

### 💬 참고 사항 (선택 사항)
<!-- 리뷰 시 참고해야 할 내용이나 전달하고 싶은 사항이 있다면 작성해주세요 -->
