### PR TITLE
Remove GetPullRequestComments method

### DIFF
--- a/Services/GitHubService.cs
+++ b/Services/GitHubService.cs
@@ -305,17 +305,6 @@ namespace RepoScore.Services
             return claimsData;
         }
 
-        public List<string> GetPullRequestComments(int prNumber)
-        {
-            var query = new Octokit.GraphQL.Query()
-                .Repository(_repo, _owner)
-                .PullRequest(prNumber)
-                .Comments(first: 50)
-                .Nodes.Select(c => c.Body);
-
-            return _graphQLConnection.Run(query).Result.ToList();
-        }
-
         private bool HasLinkedPullRequest(int issueNumber)
         {
             try


### PR DESCRIPTION
Removed the GetPullRequestComments method from GitHubService. Closes #374

### ISSUE_ID
Closes #374 

### 변경사항
- [ ] Services/GitHubService.cs 내에서 호출되지 않는 GetPullRequestComments 메소드 제거
- [ ] 불필요한 코드를 정리하여 코드베이스 최적화

### 🧪 테스트 방법 (선택 사항)


### 💬 참고 사항 (선택 사항)

