### PR TITLE
이슈와 연결된 PR 정보 받아오는 로직 최적화

### DIFF
--- a/Services/GitHubService.cs
+++ b/Services/GitHubService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using Octokit.GraphQL;
 using Octokit.GraphQL.Model;
 
@@ -47,6 +48,12 @@ namespace RepoScore.Services
         public bool IsMerged { get; set; } = false;
         public List<GitHubIssuePrLabel> Labels { get; set; } = new();
         public DateTimeOffset UpdatedAt { get; set; }
+    }
+
+    public class PRWithLinkedIssues
+    {
+        public PRRecord Pr { get; set; } = new();
+        public List<int> LinkedIssueNumbers { get; set; } = new();
     }
 
     // GitHub REST/GraphQL API를 통해 저장소 데이터를 조회하는 서비스 클래스.
@@ -236,6 +243,8 @@ namespace RepoScore.Services
             bool hasNextPage = true;
             var now = DateTimeOffset.UtcNow;
 
+            List<PRWithLinkedIssues> openPrs = GetOpenPullRequestsWithLinkedIssues();
+
             while (hasNextPage)
             {
                 var query = new Octokit.GraphQL.Query()
@@ -277,7 +286,7 @@ namespace RepoScore.Services
                         {
                             var deadlineHours = IsDocumentTask(issueLabels) ? 24.0 : 48.0;
                             var remaining = comment.CreatedAt.AddHours(deadlineHours) - now;
-                            var hasPr = issue.Number > 0 && HasLinkedPullRequest(issue.Number);
+                            var hasPr = issue.Number > 0 && openPrs.Any(pr => pr.LinkedIssueNumbers.Contains(issue.Number));
 
                             if (!claimsData.ClaimedMap.ContainsKey(login))
                                 claimsData.ClaimedMap[login] = new List<IssueRecord>();
@@ -305,26 +314,73 @@ namespace RepoScore.Services
             return claimsData;
         }
 
-        private bool HasLinkedPullRequest(int issueNumber)
+        public List<PRWithLinkedIssues> GetOpenPullRequestsWithLinkedIssues()
         {
-            try
+            var prsWithIssues = new List<PRWithLinkedIssues>();
+            string? cursor = null;
+            bool hasNextPage = true;
+
+            // 이슈 번호 파싱을 위한 정규식 (예: #312, URL 해시 제외)
+            var regex = new Regex(@"(?<!\w)#(\d+)\b");
+
+            while (hasNextPage)
             {
                 var query = new Octokit.GraphQL.Query()
                     .Repository(_repo, _owner)
-                    .Issue(issueNumber)
-                    .TimelineItems(first: 50)
-                    .Nodes
-                    .OfType<CrossReferencedEvent>()
-                    .Select(e => e.Url);
+                    .PullRequests(first: 100, states: new[] { PullRequestState.Open }, after: cursor)
+                    .Select(s => new
+                    {
+                        s.PageInfo.HasNextPage,
+                        s.PageInfo.EndCursor,
+                        Items = s.Nodes.Select(pr => new
+                        {
+                            pr.Number,
+                            pr.Title,
+                            pr.Url,
+                            pr.Body,
+                            pr.UpdatedAt,
+                            Labels = pr.Labels(10, null, null, null, null).Nodes.Select(l => l.Name).ToList()
+                        }).ToList()
+                    });
 
-                var timelineUrls = _graphQLConnection.Run(query).Result;
+                var result = _graphQLConnection.Run(query).Result;
 
-                return timelineUrls.Any(url => !string.IsNullOrEmpty(url) && url.Contains("/pull/"));
+                foreach (var pr in result.Items)
+                {
+                    var linkedIssueNumbers = new HashSet<int>();
+
+                    if (!string.IsNullOrWhiteSpace(pr.Body))
+                    {
+                        var matches = regex.Matches(pr.Body);
+                        foreach (Match match in matches)
+                        {
+                            if (match.Groups.Count > 1 && int.TryParse(match.Groups[1].Value, out int issueNum))
+                            {
+                                linkedIssueNumbers.Add(issueNum);
+                            }
+                        }
+                    }
+
+                    prsWithIssues.Add(new PRWithLinkedIssues
+                    {
+                        Pr = new PRRecord
+                        {
+                            Number = pr.Number,
+                            Title = pr.Title,
+                            Url = pr.Url,
+                            IsMerged = false, // Open 상태인 PR들만 필터링했으므로 false
+                            UpdatedAt = pr.UpdatedAt,
+                            Labels = pr.Labels.Select(ParseGitHubLabel).Where(l => l != GitHubIssuePrLabel.None).ToList()
+                        },
+                        LinkedIssueNumbers = linkedIssueNumbers.ToList()
+                    });
+                }
+
+                hasNextPage = result.HasNextPage;
+                cursor = result.EndCursor;
             }
-            catch
-            {
-                return false;
-            }
+
+            return prsWithIssues;
         }
 
         internal static bool IsDocumentTask(List<GitHubIssuePrLabel> issueLabels)


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #382

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- [ ]  HasLinkedPullRequest 메소드 삭제
- [ ] GetOpenPullRequestsWithLinkedIssues 메소드 작성
- [ ] 기존에 이슈와 연결된 PR 정보를 하나씩 받아오는 로직을 오픈된 PR을 한번에 받아와 연결된 이슈를 파싱하는 로직으로 수정

### 🧪 테스트 방법 (선택 사항)
dotnet run -- oss2026hnu/reposcore-cs oss2026hnu/reposcore-ts --token {토큰} --claims=

위 명령어 실행하여 정상 동작하는지 확인

### 💬 참고 사항 (선택 사항)

현재 GraphQL로는 이슈를 조회하면서 연결된 PR 정보를 받아올수 없습니다.

이슈를 timelineItems 데이터를 받아와서 해당 데이터에 CrossReferencedEvent 정보를 확인해야하는데
GraphQL 로는 다른 이벤트들은 받아올수 있는데 CrossReferencedEvent 정보만 못받아오고 있습니다.
rawGraphQl 방식으로도 시도 했지만 받아오는데 실패했습니다.

확인 결과 restAPI는 해당 정보를 받아올 수 있을거로 파악되지만
GraphQL로는 CrossReferencedEvent를 받아오는데에는 제한이 있는것 같습니다.
CrossReferencedEvent가 안정적이지 못한것 같습니다.

그래서 성능 최적화 방향성을 이슈를 받아오는 쿼리에 연결된 PR 정보를 한번에 받아오는 방식이 아닌
현재 오픈되어 있는 PR들을 한번에 받아와 코맨트를 파싱하여 이슈와 연결하는 방식으로 진행했습니다.

HasLinkedPullRequest 함수는 이슈번호를 파라미터로 받아 이슈마다 매번 새로운 쿼리를 날려야 하기때문에 n번의 호출이 필요하지만
GetOpenPullRequestsWithLinkedIssues 함수는 현재 열려있는 PR을 한번에 받아오는 방식으로 변경하여 한번의 호출로 성능을 올릴수 있습니다.

참고적으로 기존에 있던 HasLinkedPullRequest 함수는 CrossReferencedEvent 받아오는 형태의 코드였기 때문에 정상동작하지 않은것으로 파악됩니다.