### PR TITLE
PR 쿼리 최적화 (유저 별이 아닌 모든 유저의 PR정보 받아오기)

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -102,12 +102,15 @@ CoconaApp.Run((
             List<string> contributors = service.GetAllContributors();
             if (contributors.Count == 0) { Console.Error.WriteLine("조회된 기여자가 없습니다."); continue; }
 
+            // 모든 PR 데이터를 한 번에 가져와서 루프 내에서 필터링 (N+1 최적화)
+            var allNewPrs = service.GetPullRequests(since);
+
             var reportData = new List<(string Id, int docIssues, int featBugIssues, int typoPrs, int docPrs, int featBugPrs, int Score)>();
 
             foreach (var user in contributors)
             {
                 var newIssues = service.GetIssues(user, since);
-                var newPrs = service.GetPullRequests(user, since);
+                var newPrs = allNewPrs.Where(p => p.AuthorLogin == user).ToList();
 
                 if (!cache.UserIssues.ContainsKey(user)) cache.UserIssues[user] = new List<IssueRecord>();
                 if (!cache.UserPullRequests.ContainsKey(user)) cache.UserPullRequests[user] = new List<PRRecord>();

--- a/Services/GitHubService.cs
+++ b/Services/GitHubService.cs
@@ -45,6 +45,7 @@ namespace RepoScore.Services
         public int Number { get; set; }
         public string Url { get; set; } = string.Empty;
         public string Title { get; set; } = string.Empty;
+        public string AuthorLogin { get; set; } = string.Empty;
         public bool IsMerged { get; set; } = false;
         public List<GitHubIssuePrLabel> Labels { get; set; } = new();
         public DateTimeOffset UpdatedAt { get; set; }
@@ -79,11 +80,11 @@ namespace RepoScore.Services
                 new Octokit.GraphQL.ProductHeaderValue("reposcore-cs"), token);
         }
 
-        // 특정 사용자가 작성하고 머지된 PR 목록을 GraphQL로 조회.
+        // 저장소의 머지된 전체 PR 목록을 GraphQL로 조회.
         // since가 지정된 경우 해당 시각 이후 업데이트된 PR만 가져옴.
-        public List<PRRecord> GetPullRequests(string authorLogin, DateTimeOffset? since = null)
+        public List<PRRecord> GetPullRequests(DateTimeOffset? since = null)
         {
-            string searchString = $"repo:{_owner}/{_repo} is:pr is:merged author:{authorLogin}";
+            string searchString = $"repo:{_owner}/{_repo} is:pr is:merged";
             if (since.HasValue)
             {
                 searchString += $" updated:>={since.Value.ToUniversalTime():yyyy-MM-ddTHH:mm:ssZ}";
@@ -108,6 +109,7 @@ namespace RepoScore.Services
                             pr.Url,
                             pr.Merged,
                             pr.UpdatedAt,
+                            AuthorLogin = pr.Author.Login,
                             Labels = pr.Labels(10, null, null, null, null).Nodes.Select(l => l.Name).ToList()
                         }).ToList()
                     });
@@ -121,6 +123,7 @@ namespace RepoScore.Services
                         Number = pr.Number,
                         Title = pr.Title,
                         Url = pr.Url,
+                        AuthorLogin = pr.AuthorLogin ?? "",
                         IsMerged = pr.Merged,
                         UpdatedAt = pr.UpdatedAt,
                         Labels = pr.Labels.Select(ParseGitHubLabel).Where(l => l != GitHubIssuePrLabel.None).ToList()
@@ -339,6 +342,7 @@ namespace RepoScore.Services
                             pr.Url,
                             pr.Body,
                             pr.UpdatedAt,
+                            AuthorLogin = pr.Author.Login,
                             Labels = pr.Labels(10, null, null, null, null).Nodes.Select(l => l.Name).ToList()
                         }).ToList()
                     });
@@ -368,6 +372,7 @@ namespace RepoScore.Services
                             Number = pr.Number,
                             Title = pr.Title,
                             Url = pr.Url,
+                            AuthorLogin = pr.AuthorLogin ?? "",
                             IsMerged = false, // Open 상태인 PR들만 필터링했으므로 false
                             UpdatedAt = pr.UpdatedAt,
                             Labels = pr.Labels.Select(ParseGitHubLabel).Where(l => l != GitHubIssuePrLabel.None).ToList()


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #390

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- [ ] GithubService.cs파일의 기존 PR 메소드를 List<PRRecord> GetPullRequests(DateTimeOffset? since = null) 메소드로 변경
- [ ] Program.cs 파일의 PR 처리 로직 수정 

### 🧪 테스트 방법 (선택 사항)
dotnet run -- oss2026hnu/reposcore-cs oss2026hnu/reposcore-ts --token {토큰}

위 명령어를 실행하여 정상동작 확인

### 💬 참고 사항 (선택 사항)

