### PR TITLE
이슈 쿼리 최적화

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -102,11 +102,14 @@ CoconaApp.Run((
             List<string> contributors = service.GetAllContributors();
             if (contributors.Count == 0) { Console.Error.WriteLine("조회된 기여자가 없습니다."); continue; }
 
+            // 모든 PR 데이터를 한 번에 가져와서 루프 내에서 필터링 (N+1 최적화)
+            var allNewIssues = service.GetIssues(since);
+
             var reportData = new List<(string Id, int docIssues, int featBugIssues, int typoPrs, int docPrs, int featBugPrs, int Score)>();
 
             foreach (var user in contributors)
             {
-                var newIssues = service.GetIssues(user, since);
+                var newIssues = allNewIssues.Where(i => i.AuthorLogin == user).ToList();
                 var newPrs = service.GetPullRequests(user, since);
 
                 if (!cache.UserIssues.ContainsKey(user)) cache.UserIssues[user] = new List<IssueRecord>();

--- a/Services/GitHubService.cs
+++ b/Services/GitHubService.cs
@@ -27,6 +27,7 @@ namespace RepoScore.Services
         public int Number { get; set; }
         public string Url { get; set; } = string.Empty;
         public string Title { get; set; } = string.Empty;
+        public string AuthorLogin { get; set; } = string.Empty;
         public bool HasPr { get; set; }
         public IssueClosedStateReason ClosedReason { get; set; } = IssueClosedStateReason.None;
         public TimeSpan Remaining { get; set; }
@@ -134,10 +135,10 @@ namespace RepoScore.Services
             return prRecords;
         }
 
-        // 특정 사용자가 작성한 이슈 목록을 GraphQL로 조회.
+        // 저장소의 전체 이슈 목록을 GraphQL로 조회.
         // "not planned", "duplicate" 사유로 닫힌 이슈는 제외.
         // since가 지정된 경우 해당 시각 이후 업데이트된 이슈만 가져옴.
-        public List<IssueRecord> GetIssues(string authorLogin, DateTimeOffset? since = null)
+        public List<IssueRecord> GetIssues(DateTimeOffset? since = null)
         {
             const string rawGraphQl = @"
             query($searchQuery: String!, $after: String) {
@@ -153,6 +154,9 @@ namespace RepoScore.Services
                             url
                             stateReason
                             updatedAt
+                            author {
+                                login
+                            }
                             labels(first: 10) {
                                 nodes {
                                     name
@@ -163,7 +167,7 @@ namespace RepoScore.Services
                 }
             }";
 
-            string searchString = $"repo:{_owner}/{_repo} is:issue author:{authorLogin} -reason:\"not planned\" -reason:\"duplicate\"";
+            string searchString = $"repo:{_owner}/{_repo} is:issue -reason:\"not planned\" -reason:\"duplicate\"";
             if (since.HasValue)
             {
                 searchString += $" updated:>={since.Value.ToUniversalTime():yyyy-MM-ddTHH:mm:ssZ}";
@@ -218,11 +222,21 @@ namespace RepoScore.Services
                         var updatedAt = node.TryGetProperty("updatedAt", out var updatedElement)
                             ? DateTimeOffset.Parse(updatedElement.GetString()!) : DateTimeOffset.MinValue;
 
+                        string authorLogin = "";
+                        if (node.TryGetProperty("author", out var authorElement) && authorElement.ValueKind == JsonValueKind.Object)
+                        {
+                            if (authorElement.TryGetProperty("login", out var loginElement))
+                            {
+                                authorLogin = loginElement.GetString() ?? "";
+                            }
+                        }
+
                         issueRecords.Add(new IssueRecord
                         {
                             Number = node.TryGetProperty("number", out var numEl) ? numEl.GetInt32() : 0,
                             Title = node.TryGetProperty("title", out var titEl) ? titEl.GetString() ?? "" : "",
                             Url = node.TryGetProperty("url", out var urlEl) ? urlEl.GetString() ?? "" : "",
+                            AuthorLogin = authorLogin,
                             ClosedReason = ParseIssueClosedStateReason(node),
                             Labels = labelNames.Select(ParseGitHubLabel).Where(l => l != GitHubIssuePrLabel.None).ToList(),
                             UpdatedAt = updatedAt


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #392

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- [ ] GithubService.cs파일의 기존 이슈 메소드를 List GetIssues(DateTimeOffset? since = null) 메소드로 변경
- [ ] Program.cs 파일의 이슈 처리 로직 수정

### 🧪 테스트 방법 (선택 사항)
dotnet run -- oss2026hnu/reposcore-cs oss2026hnu/reposcore-ts --token {토큰}

위 명령어를 실행하여 정상 동작 여부 확인

### 💬 참고 사항 (선택 사항)