### PR TITLE
이슈 선점 PR정보 표시 추가

### DIFF
--- a/Data/Reportformatter.cs
+++ b/Data/Reportformatter.cs
@@ -98,7 +98,7 @@ namespace RepoScore.Data
                         {
                             sb.AppendLine($" - {claim.Url}");
                             if (claim.Labels.Count > 0) sb.AppendLine($"   라벨: {string.Join(", ", claim.Labels)}");
-                            sb.AppendLine(claim.HasPr ? "   PR 생성됨" : FormatRemainingTime(claim.Remaining));
+                            sb.AppendLine(FormatClaimStatus(claim));
                         }
                     }
                 }
@@ -116,7 +116,7 @@ namespace RepoScore.Data
                         sb.AppendLine($" #{claim.Number} {claim.Url}");
                         sb.AppendLine($"   선점자: {login}");
                         if (claim.Labels.Count > 0) sb.AppendLine($"   라벨: {string.Join(", ", claim.Labels)}");
-                        sb.AppendLine(claim.HasPr ? "   PR 생성됨" : FormatRemainingTime(claim.Remaining));
+                        sb.AppendLine(FormatClaimStatus(claim));
                     }
                 }
 
@@ -128,6 +128,22 @@ namespace RepoScore.Data
             }
 
             return sb.ToString();
+        }
+
+        public static string FormatClaimStatus(IssueRecord claim)
+        {
+            if (!claim.HasPr)
+            {
+                return FormatRemainingTime(claim.Remaining);
+            }
+
+            if (claim.LinkedPullRequests != null && claim.LinkedPullRequests.Count > 0)
+            {
+                var prNumbers = string.Join(", ", claim.LinkedPullRequests.Select(pr => $"#{pr.Number}"));
+                return $"   PR 생성됨 - {prNumbers}";
+            }
+
+            return "   PR 생성됨";
         }
 
         public static string FormatRemainingTime(TimeSpan remaining)

--- a/RepoScore.Tests/ReportFormatterTests.cs
+++ b/RepoScore.Tests/ReportFormatterTests.cs
@@ -1,0 +1,36 @@
+using RepoScore.Data;
+using RepoScore.Services;
+using Xunit;
+
+namespace RepoScore.Tests;
+
+public class ReportFormatterTests
+{
+    [Fact]
+    public void BuildClaimsReport_IncludesLinkedPrNumber_WhenIssueHasLinkedPr()
+    {
+        var data = new ClaimsData
+        {
+            ClaimedMap = new Dictionary<string, List<IssueRecord>>
+            {
+                ["arror1784"] = new List<IssueRecord>
+                {
+                    new IssueRecord
+                    {
+                        Number = 392,
+                        Url = "https://github.com/oss2026hnu/reposcore-cs/issues/392",
+                        HasPr = true,
+                        LinkedPullRequests = new List<PRRecord>
+                        {
+                            new PRRecord { Number = 393, Url = "https://github.com/oss2026hnu/reposcore-cs/pull/393", Title = "Fix issue 392" }
+                        }
+                    }
+                }
+            }
+        };
+
+        string report = ReportFormatter.BuildClaimsReport(data, "repo");
+
+        Assert.Contains("PR 생성됨 - #393", report);
+    }
+}

--- a/Services/GitHubService.cs
+++ b/Services/GitHubService.cs
@@ -28,6 +28,7 @@ namespace RepoScore.Services
         public string Url { get; set; } = string.Empty;
         public string Title { get; set; } = string.Empty;
         public bool HasPr { get; set; }
+        public List<PRRecord> LinkedPullRequests { get; set; } = new();
         public IssueClosedStateReason ClosedReason { get; set; } = IssueClosedStateReason.None;
         public TimeSpan Remaining { get; set; }
         public List<GitHubIssuePrLabel> Labels { get; set; } = new();
@@ -45,7 +46,6 @@ namespace RepoScore.Services
         public int Number { get; set; }
         public string Url { get; set; } = string.Empty;
         public string Title { get; set; } = string.Empty;
-        public string AuthorLogin { get; set; } = string.Empty;
         public bool IsMerged { get; set; } = false;
         public List<GitHubIssuePrLabel> Labels { get; set; } = new();
         public DateTimeOffset UpdatedAt { get; set; }
@@ -80,11 +80,11 @@ namespace RepoScore.Services
                 new Octokit.GraphQL.ProductHeaderValue("reposcore-cs"), token);
         }
 
-        // 저장소의 머지된 전체 PR 목록을 GraphQL로 조회.
+        // 특정 사용자가 작성하고 머지된 PR 목록을 GraphQL로 조회.
         // since가 지정된 경우 해당 시각 이후 업데이트된 PR만 가져옴.
-        public List<PRRecord> GetPullRequests(DateTimeOffset? since = null)
+        public List<PRRecord> GetPullRequests(string authorLogin, DateTimeOffset? since = null)
         {
-            string searchString = $"repo:{_owner}/{_repo} is:pr is:merged";
+            string searchString = $"repo:{_owner}/{_repo} is:pr is:merged author:{authorLogin}";
             if (since.HasValue)
             {
                 searchString += $" updated:>={since.Value.ToUniversalTime():yyyy-MM-ddTHH:mm:ssZ}";
@@ -109,7 +109,6 @@ namespace RepoScore.Services
                             pr.Url,
                             pr.Merged,
                             pr.UpdatedAt,
-                            AuthorLogin = pr.Author.Login,
                             Labels = pr.Labels(10, null, null, null, null).Nodes.Select(l => l.Name).ToList()
                         }).ToList()
                     });
@@ -123,7 +122,6 @@ namespace RepoScore.Services
                         Number = pr.Number,
                         Title = pr.Title,
                         Url = pr.Url,
-                        AuthorLogin = pr.AuthorLogin ?? "",
                         IsMerged = pr.Merged,
                         UpdatedAt = pr.UpdatedAt,
                         Labels = pr.Labels.Select(ParseGitHubLabel).Where(l => l != GitHubIssuePrLabel.None).ToList()
@@ -289,7 +287,11 @@ namespace RepoScore.Services
                         {
                             var deadlineHours = IsDocumentTask(issueLabels) ? 24.0 : 48.0;
                             var remaining = comment.CreatedAt.AddHours(deadlineHours) - now;
-                            var hasPr = issue.Number > 0 && openPrs.Any(pr => pr.LinkedIssueNumbers.Contains(issue.Number));
+                            var linkedPrs = openPrs
+                                .Where(pr => pr.LinkedIssueNumbers.Contains(issue.Number))
+                                .Select(pr => pr.Pr)
+                                .ToList();
+                            var hasPr = linkedPrs.Count > 0;
 
                             if (!claimsData.ClaimedMap.ContainsKey(login))
                                 claimsData.ClaimedMap[login] = new List<IssueRecord>();
@@ -299,6 +301,7 @@ namespace RepoScore.Services
                                 Number = issue.Number,
                                 Url = issue.Url,
                                 HasPr = hasPr,
+                                LinkedPullRequests = linkedPrs,
                                 Remaining = remaining,
                                 Labels = issueLabels
                             });
@@ -342,7 +345,6 @@ namespace RepoScore.Services
                             pr.Url,
                             pr.Body,
                             pr.UpdatedAt,
-                            AuthorLogin = pr.Author.Login,
                             Labels = pr.Labels(10, null, null, null, null).Nodes.Select(l => l.Name).ToList()
                         }).ToList()
                     });
@@ -372,7 +374,6 @@ namespace RepoScore.Services
                             Number = pr.Number,
                             Title = pr.Title,
                             Url = pr.Url,
-                            AuthorLogin = pr.AuthorLogin ?? "",
                             IsMerged = false, // Open 상태인 PR들만 필터링했으므로 false
                             UpdatedAt = pr.UpdatedAt,
                             Labels = pr.Labels.Select(ParseGitHubLabel).Where(l => l != GitHubIssuePrLabel.None).ToList()


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #394 

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- [ ] 클레임의 PR정보를 알수있게 출력
- [ ] 리포트 포맷터 구현, GitHub 서비스 연계, 테스트 코드 추가

### 🧪 테스트 방법 (선택 사항)
dotnet run -- oss2026hnu/reposcore-cs oss2026hnu/reposcore-ts --claims= 실행하여 테스트

### 💬 참고 사항 (선택 사항)
<!-- 리뷰 시 참고해야 할 내용이나 전달하고 싶은 사항이 있다면 작성해주세요 -->
