### PR TITLE
results.txt 결과 출력 포멧 수정 (중복되는 추가제안 내용 삭제)

### DIFF
--- a/Data/Reportformatter.cs
+++ b/Data/Reportformatter.cs
@@ -63,9 +63,31 @@ namespace RepoScore.Data
                 int totalIssues = r.featBugIssues + r.docIssues;
                 int rejectedIssue = Math.Max(0, totalIssues - maxIssueCount);
 
-                sb.AppendLine($"   [미인정 항목] 문서/오타 PR {rejectedPr}개 초과(한도 {maxAdditionalPr}개) / 이슈 {rejectedIssue}개 초과(한도 {maxIssueCount}개)");
-                sb.AppendLine($"   [추가 제안] 기능/버그 PR 1개 추가 시 이슈 인정 한도 +4, 문서PR 인정 한도 +3");
-                sb.AppendLine();
+                if (rejectedPr > 0 || rejectedIssue > 0)
+                {
+                    sb.AppendLine($"   [미인정 항목] 문서/오타 PR {rejectedPr}개 초과(한도 {maxAdditionalPr}개) / 이슈 {rejectedIssue}개 초과(한도 {maxIssueCount}개)");
+
+                    if (rejectedPr > 0)
+                    {
+                        int docSuggestionCount = (rejectedPr + 2) / 3;
+                        sb.AppendLine($"   [추가 제안] 기능/버그 PR {docSuggestionCount}개 추가 시 문서PR 인정 한도 +{docSuggestionCount * 3}");
+                    }
+
+                    if (rejectedIssue > 0)
+                    {
+                        int issueSuggestionCount = (rejectedIssue + 3) / 4;
+                        if (totalDocTypoPr < maxAdditionalPr)
+                        {
+                            sb.AppendLine($"   [추가 제안] 문서 PR {issueSuggestionCount}개 추가 혹은 기능/버그 PR {issueSuggestionCount}개 추가시 이슈 인정한도 +{issueSuggestionCount * 4}");
+                        }
+                        else
+                        {
+                            sb.AppendLine($"   [추가 제안] 기능/버그 PR {issueSuggestionCount}개 추가시 이슈 인정한도 +{issueSuggestionCount * 4}");
+                        }
+                    }
+
+                    sb.AppendLine();
+                }
             }
 
             return sb.ToString();

--- a/RepoScore.Tests/ReportFormatterTests.cs
+++ b/RepoScore.Tests/ReportFormatterTests.cs
@@ -33,4 +33,86 @@ public class ReportFormatterTests
 
         Assert.Contains("PR 생성됨 - #393", report);
     }
+
+    [Fact]
+    public void BuildTextReport_DoesNotIncludeSuggestion_WhenNoOverflow()
+    {
+        var reportData = new List<(string Id, int docIssues, int featBugIssues, int typoPrs, int docPrs, int featBugPrs, int Score)>
+        {
+            ("user1", 1, 1, 0, 0, 1, 10)
+        };
+
+        string report = ReportFormatter.BuildTextReport("repo", reportData);
+
+        Assert.DoesNotContain("[추가 제안]", report);
+    }
+
+    [Fact]
+    public void BuildTextReport_IncludesDocPrSuggestion_WhenDocOverflowOnly()
+    {
+        var reportData = new List<(string Id, int docIssues, int featBugIssues, int typoPrs, int docPrs, int featBugPrs, int Score)>
+        {
+            ("user2", 0, 1, 1, 3, 1, 0)
+        };
+
+        string report = ReportFormatter.BuildTextReport("repo", reportData);
+
+        Assert.Contains("   [추가 제안] 기능/버그 PR 1개 추가 시 문서PR 인정 한도 +3", report);
+        Assert.DoesNotContain("이슈 인정 한도 +4", report);
+    }
+
+    [Fact]
+    public void BuildTextReport_IncludesDynamicDocSuggestion_WhenDocOverflowRequiresMultiplePrs()
+    {
+        var reportData = new List<(string Id, int docIssues, int featBugIssues, int typoPrs, int docPrs, int featBugPrs, int Score)>
+        {
+            ("user2", 0, 1, 2, 5, 1, 0)
+        };
+
+        string report = ReportFormatter.BuildTextReport("repo", reportData);
+
+        Assert.Contains("   [추가 제안] 기능/버그 PR 2개 추가 시 문서PR 인정 한도 +6", report);
+    }
+
+    [Fact]
+    public void BuildTextReport_IncludesIssueSuggestion_WhenIssueOverflowAndDocUnderLimit()
+    {
+        var reportData = new List<(string Id, int docIssues, int featBugIssues, int typoPrs, int docPrs, int featBugPrs, int Score)>
+        {
+            ("user3", 9, 0, 1, 0, 1, 0)
+        };
+
+        string report = ReportFormatter.BuildTextReport("repo", reportData);
+
+        Assert.Contains("   [추가 제안] 문서 PR 1개 추가 혹은 기능/버그 PR 1개 추가시 이슈 인정한도 +4", report);
+        Assert.DoesNotContain("기능/버그 PR 1개 추가 시 문서PR 인정 한도 +3", report);
+    }
+
+    [Fact]
+    public void BuildTextReport_IncludesDynamicIssueSuggestion_WhenIssueOverflowRequiresMultiplePrs()
+    {
+        var reportData = new List<(string Id, int docIssues, int featBugIssues, int typoPrs, int docPrs, int featBugPrs, int Score)>
+        {
+            ("user5", 21, 0, 0, 0, 1, 0)
+        };
+
+        string report = ReportFormatter.BuildTextReport("repo", reportData);
+
+        Assert.Contains("   [추가 제안] 문서 PR 5개 추가 혹은 기능/버그 PR 5개 추가시 이슈 인정한도 +20", report);
+        Assert.DoesNotContain("기능/버그 PR 1개 추가 시 문서PR 인정 한도 +3", report);
+    }
+
+    [Fact]
+    public void BuildTextReport_IncludesIssueSuggestion_WhenIssueOverflowAndDocLimitReached()
+    {
+        var reportData = new List<(string Id, int docIssues, int featBugIssues, int typoPrs, int docPrs, int featBugPrs, int Score)>
+        {
+            ("user4", 17, 0, 3, 0, 1, 0)
+        };
+
+        string report = ReportFormatter.BuildTextReport("repo", reportData);
+
+        Assert.Contains("   [추가 제안] 기능/버그 PR 1개 추가시 이슈 인정한도 +4", report);
+        Assert.DoesNotContain("기능/버그 PR 1개 추가 시 문서PR 인정 한도 +3", report);
+    }
 }


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #402 

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- [ ] 이슈와 PR이 초과되는 인원에게만 초과갯수와 추가제안이 표시되도록 수정
- [ ] 문서/오타 PR 초과 갯수에 따라 필요한 기능/버그 PR 개수를 동적으로 계산
- [ ] 이슈 초과 갯수에 따라 필요한 PR 개수를 동적으로 계산 (4개 단위)

### 🧪 테스트 방법 (선택 사항)
<!-- 변경 사항이 정상 동작하는지 어떻게 확인했는지 작성해주세요 -->
dotnet run — oss2026hnu/reposcore-cs oss2026hnu/reposcore-ts —token YOUR_GITHUB_TOKEN --format=txt 실행

### 💬 참고 사항 (선택 사항)
<!-- 리뷰 시 참고해야 할 내용이나 전달하고 싶은 사항이 있다면 작성해주세요 -->
