### PR TITLE
README의 --claims 옵션 사용 예시 형식 통일 

### DIFF
--- a/README-template.md
+++ b/README-template.md
@@ -29,9 +29,9 @@ dotnet run -- oss2026hnu/reposcore-cs --token YOUR_GITHUB_TOKEN
 dotnet run -- oss2026hnu/reposcore-cs oss2026hnu/reposcore-ts --token YOUR_GITHUB_TOKEN
 
 # 최근 이슈 선점 현황 조회 예시 (Codespaces 환경에서는 토큰 생략 가능)
-dotnet run -- oss2026hnu/reposcore-cs --claims= --token YOUR_GITHUB_TOKEN      # 이슈별 (기본값)
-dotnet run -- oss2026hnu/reposcore-cs --claims=issue --token YOUR_GITHUB_TOKEN # 이슈별 (명시)
-dotnet run -- oss2026hnu/reposcore-cs --claims=user --token YOUR_GITHUB_TOKEN  # 유저별
+dotnet run -- oss2026hnu/reposcore-cs --claims --token YOUR_GITHUB_TOKEN      # 이슈별 (기본값)
+dotnet run -- oss2026hnu/reposcore-cs --claims issue --token YOUR_GITHUB_TOKEN # 이슈별 (명시)
+dotnet run -- oss2026hnu/reposcore-cs --claims user --token YOUR_GITHUB_TOKEN  # 유저별
 
 # 도움말 출력 (모든 인수 및 옵션 확인)
 dotnet run -- --help

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ dotnet run -- oss2026hnu/reposcore-cs --token YOUR_GITHUB_TOKEN
 dotnet run -- oss2026hnu/reposcore-cs oss2026hnu/reposcore-ts --token YOUR_GITHUB_TOKEN
 
 # 최근 이슈 선점 현황 조회 예시 (Codespaces 환경에서는 토큰 생략 가능)
-dotnet run -- oss2026hnu/reposcore-cs --claims= --token YOUR_GITHUB_TOKEN      # 이슈별 (기본값)
-dotnet run -- oss2026hnu/reposcore-cs --claims=issue --token YOUR_GITHUB_TOKEN # 이슈별 (명시)
-dotnet run -- oss2026hnu/reposcore-cs --claims=user --token YOUR_GITHUB_TOKEN  # 유저별
+dotnet run -- oss2026hnu/reposcore-cs --claims --token YOUR_GITHUB_TOKEN      # 이슈별 (기본값)
+dotnet run -- oss2026hnu/reposcore-cs --claims issue --token YOUR_GITHUB_TOKEN # 이슈별 (명시)
+dotnet run -- oss2026hnu/reposcore-cs --claims user --token YOUR_GITHUB_TOKEN  # 유저별
 
 # 도움말 출력 (모든 인수 및 옵션 확인)
 dotnet run -- --help

--- a/docs/cli-options-guide.md
+++ b/docs/cli-options-guide.md
@@ -112,20 +112,20 @@ dotnet run -- oss2026hnu/reposcore-cs
 | 항목 | 내용 |
 |---|---|
 | 허용 값 | `issue` (이슈별 표시), `user` (유저별 표시) |
-| 기본값 | `issue` (값 없이 `--claims=`만 입력 시) |
+| 기본값 | `issue` (값 없이 `--claims`만 입력 시) |
 
 ```bash
 # 이슈별 선점 현황 (기본값)
-dotnet run -- oss2026hnu/reposcore-cs --claims= --token ghp_xxxxx
+dotnet run -- oss2026hnu/reposcore-cs --claims --token ghp_xxxxx
 
 # 이슈별 선점 현황 (명시)
-dotnet run -- oss2026hnu/reposcore-cs --claims=issue --token ghp_xxxxx
+dotnet run -- oss2026hnu/reposcore-cs --claims issue --token ghp_xxxxx
 
 # 유저별 선점 현황
-dotnet run -- oss2026hnu/reposcore-cs --claims=user --token ghp_xxxxx
+dotnet run -- oss2026hnu/reposcore-cs --claims user --token ghp_xxxxx
 ```
 
-> ⚠️  `--claims=issue` 또는 `--claims issue` 형식 모두 사용 가능합니다.
+> ⚠️ `--claims issue` 또는 `--claims user` 형식으로 사용할 수 있습니다.
 
 ---
 
@@ -270,10 +270,10 @@ dotnet run -- oss2026hnu/reposcore-cs -t ghp_xxxxx --sort-by score --sort-order 
 
 ```bash
 # 이슈별 조회 (기본)
-dotnet run -- oss2026hnu/reposcore-cs --claims= -t ghp_xxxxx
+dotnet run -- oss2026hnu/reposcore-cs --claims -t ghp_xxxxx
 
 # 유저별 조회
-dotnet run -- oss2026hnu/reposcore-cs --claims=user -t ghp_xxxxx
+dotnet run -- oss2026hnu/reposcore-cs --claims user -t ghp_xxxxx
 ```
 
 ### 출력 경로 + 커스텀 키워드


### PR DESCRIPTION
Closes #404

`README-template.md`의 `--claims` 사용 예시를 `--help` 출력 형식에 맞춰 공백 구분 방식으로 통일했습니다.

### 변경사항
- `README-template.md`의 `--claims` 예시 형식 통일
- `docs/cli-options-guide.md`의 관련 예시 형식 통일
- `README.md` 자동 생성 결과 반영

### 참고
- `README-template.md` 수정 후 `README.md`도 함께 갱신했습니다.