### PR TITLE
기여도 분석 결과를 막대 그래프 등 시각적 차트로 출력하는 html 포맷 추가

### DIFF
--- a/Data/Reportformatter.cs
+++ b/Data/Reportformatter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using RepoScore.Services;
+using System.Text.Json;
 
 namespace RepoScore.Data
 {
@@ -91,6 +92,67 @@ namespace RepoScore.Data
             }
 
             return sb.ToString();
+        }
+
+        public static string BuildHtmlReport(string repoName, List<(string Id, int docIssues, int featBugIssues, int typoPrs, int docPrs, int featBugPrs, int Score)> reportData)
+        {
+            var labels = JsonSerializer.Serialize(reportData.Select(r => $"{r.Id} (점수: {r.Score})"));
+            var featBugPrData = JsonSerializer.Serialize(reportData.Select(r => r.featBugPrs));
+            var docPrData = JsonSerializer.Serialize(reportData.Select(r => r.docPrs));
+            var typoPrData = JsonSerializer.Serialize(reportData.Select(r => r.typoPrs));
+            var featBugIssueData = JsonSerializer.Serialize(reportData.Select(r => r.featBugIssues));
+            var docIssueData = JsonSerializer.Serialize(reportData.Select(r => r.docIssues));
+
+            int chartHeight = Math.Max(400, reportData.Count * 30);
+
+            return $@"
+<!DOCTYPE html>
+<html lang=""ko"">
+<head>
+    <meta charset=""UTF-8"">
+    <meta name=""viewport"" content=""width=device-width, initial-scale=1.0"">
+    <title>RepoScore Report - {repoName}</title>
+    <script src=""https://cdn.jsdelivr.net/npm/chart.js""></script>
+    <style>
+        body {{ font-family: -apple-system, BlinkMacSystemFont, ""Segoe UI"", Helvetica, Arial, sans-serif, ""Apple Color Emoji"", ""Segoe UI Emoji""; margin: 2em; background-color: #f6f8fa; color: #24292e; }}
+        h1 {{ border-bottom: 1px solid #e1e4e8; padding-bottom: 0.3em; }}
+        .chart-container {{ position: relative; height: {chartHeight}px; width: 90vw; margin-top: 2em; background-color: #fff; border: 1px solid #e1e4e8; border-radius: 6px; padding: 1em; }}
+    </style>
+</head>
+<body>
+    <h1>RepoScore Report: {repoName}</h1>
+    <div class=""chart-container"">
+        <canvas id=""contributionChart""></canvas>
+    </div>
+    <script>
+        const ctx = document.getElementById('contributionChart');
+        new Chart(ctx, {{
+            type: 'bar',
+            data: {{
+                labels: {labels},
+                datasets: [
+                    {{ label: '문서 이슈', data: {docIssueData}, backgroundColor: '#a2eeef' }},
+                    {{ label: '기능/버그 이슈', data: {featBugIssueData}, backgroundColor: '#28a745' }},
+                    {{ label: '오타 PR', data: {typoPrData}, backgroundColor: '#fbca04' }},
+                    {{ label: '문서 PR', data: {docPrData}, backgroundColor: '#0366d6' }},
+                    {{ label: '기능/버그 PR', data: {featBugPrData}, backgroundColor: '#d73a49' }}
+                ]
+            }},
+            options: {{
+                indexAxis: 'y',
+                responsive: true,
+                maintainAspectRatio: false,
+                scales: {{ x: {{ stacked: true }}, y: {{ stacked: true }} }},
+                plugins: {{
+                    title: {{ display: true, text: '사용자별 기여 항목 분포' }},
+                    legend: {{ position: 'top' }}
+                }}
+            }}
+        }});
+    </script>
+</body>
+</html>
+";
         }
 
         public static string BuildClaimsReport(ClaimsData data, string mode)

--- a/Program.cs
+++ b/Program.cs
@@ -15,7 +15,7 @@ CoconaApp.Run((
 [Argument(Description = "대상 저장소 목록 (예: owner/repo1 owner/repo2)")] string[] repos,
 [Option('t', Description = "GitHub Token (미입력시 GITHUB_TOKEN 사용)")] string? token = null,
 [Option(Description = "최근 이슈 선점 현황 조회 (issue|user)")] string? claims = null,
-[Option('f', Description = "출력 형식 (csv, txt)")] string format = "csv",
+[Option('f', Description = "출력 형식 (csv, txt, html)")] string format = "csv",
 [Option('o', Description = "출력 디렉토리 경로")] string output = "./results",
 [Option(Description = "정렬 기준 (score | id)")] string sortBy = "score",
 [Option(Description = "정렬 방법 (asc | desc)")] string sortOrder = "desc",
@@ -26,10 +26,10 @@ CoconaApp.Run((
     token ??= Environment.GetEnvironmentVariable("GITHUB_TOKEN");
     if (string.IsNullOrEmpty(token)) { Console.Error.WriteLine("오류: GitHub 토큰이 필요합니다."); return; }
 
-    var allowedFormats = new[] { "csv", "txt" };
+    var allowedFormats = new[] { "csv", "txt", "html" };
     if (!allowedFormats.Contains(format.ToLowerInvariant()))
     {
-        Console.Error.WriteLine($"오류: 지원하지 않는 형식입니다. csv 또는 txt를 입력해 주세요. (입력값: {format})");
+        Console.Error.WriteLine($"오류: 지원하지 않는 형식입니다. csv, txt, 또는 html을 입력해 주세요. (입력값: {format})");
         return;
     }
 
@@ -201,6 +201,15 @@ CoconaApp.Run((
                 File.WriteAllText(txtPath, txtContent, Encoding.UTF8);
                 Console.Error.WriteLine($"가독성 리포트(TXT) 추가 저장 완료: {txtPath}");
             }
+
+            // HTML 리포트 생성
+            if (format.ToLower() == "html")
+            {
+                string htmlPath = Path.Combine(repoOutput, "results.html");
+                string htmlContent = ReportFormatter.BuildHtmlReport(repo, reportData);
+                File.WriteAllText(htmlPath, htmlContent, Encoding.UTF8);
+                Console.Error.WriteLine($"HTML 리포트 추가 저장 완료: {htmlPath}");
+            }
         }
         catch (Exception ex)
         {
@@ -257,6 +266,16 @@ CoconaApp.Run((
                 string totalTxtContent = ReportFormatter.BuildTextReport(totalLabel, totalReportData);
                 File.WriteAllText(totalTxtPath, totalTxtContent, Encoding.UTF8);
                 Console.Error.WriteLine($"전체 합산 리포트(TXT) 저장 완료: {totalTxtPath}");
+            }
+
+            // 합산 HTML
+            if (format.ToLower() == "html")
+            {
+                string totalLabel = string.Join(" + ", repos);
+                string totalHtmlPath = Path.Combine(totalOutput, "results.html");
+                string totalHtmlContent = ReportFormatter.BuildHtmlReport(totalLabel, totalReportData);
+                File.WriteAllText(totalHtmlPath, totalHtmlContent, Encoding.UTF8);
+                Console.Error.WriteLine($"전체 합산 HTML 리포트 저장 완료: {totalHtmlPath}");
             }
         }
         catch (Exception ex)

--- a/README-template.md
+++ b/README-template.md
@@ -52,7 +52,7 @@ Arguments:
 Options:
   -t, --token <String>     GitHub Token (미입력시 GITHUB_TOKEN 사용)
   --claims <String>        최근 이슈 선점 현황 조회 (issue|user)
-  -f, --format <String>    출력 형식 (csv, txt) (Default: csv)
+  -f, --format <String>    출력 형식 (csv, txt, html) (Default: csv)
   -o, --output <String>    출력 디렉토리 경로 (Default: ./results)
   --sort-by <String>       정렬 기준 (score | id) (Default: score)
   --sort-order <String>    정렬 방법 (asc | desc) (Default: desc)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Arguments:
 Options:
   -t, --token <String>     GitHub Token (미입력시 GITHUB_TOKEN 사용)
   --claims <String>        최근 이슈 선점 현황 조회 (issue|user)
-  -f, --format <String>    출력 형식 (csv, txt) (Default: csv)
+  -f, --format <String>    출력 형식 (csv, txt, html) (Default: csv)
   -o, --output <String>    출력 디렉토리 경로 (Default: ./results)
   --sort-by <String>       정렬 기준 (score | id) (Default: score)
   --sort-order <String>    정렬 방법 (asc | desc) (Default: desc)

--- a/docs/cli-options-guide.md
+++ b/docs/cli-options-guide.md
@@ -140,13 +140,17 @@ dotnet run -- oss2026hnu/reposcore-cs --claims=user --token ghp_xxxxx
 
 - `csv`: `results/results.csv` 파일 생성 (기본)
 - `txt`: `results/results.csv` + `results/results.txt` 파일 함께 생성
+- `html`: `results/results.csv` + `results/results.html` 파일 함께 생성 (차트 포함)
 
 ```bash
 # CSV만 생성 (기본값)
 dotnet run -- oss2026hnu/reposcore-cs -t ghp_xxxxx
 
 # CSV + TXT 함께 생성
-dotnet run -- oss2026hnu/reposcore-cs -t ghp_xxxxx --format txt
+dotnet run -- oss2026hnu/reposcore-cs -t ghp_xxxxx --format=txt
+
+# CSV + HTML 차트 리포트 함께 생성
+dotnet run -- oss2026hnu/reposcore-cs -t ghp_xxxxx --format=html
 
 # 단축 옵션
 dotnet run -- oss2026hnu/reposcore-cs -t ghp_xxxxx -f txt


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #387

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- [ ] html 포멧 기능을 추가하여 사용자별 기여도 분석 결과를 막대 그래프로 확인 가능
- [ ] docs/cli-options-guide.md 문서 파일에 html 포멧 정보 추가
- [ ] 최상위 README.md 파일 시놉시스 수정

### 🧪 테스트 방법 (선택 사항)
dotnet run -- oss2026hnu/reposcore-cs oss2026hnu/reposcore-ts --token {토큰} --format=html

위 명령어를 실행하여 ./results/results.html 파일 확인

### 💬 참고 사항 (선택 사항)
<!-- 리뷰 시 참고해야 할 내용이나 전달하고 싶은 사항이 있다면 작성해주세요 -->
