### PR TITLE
--format 등 제한된 값을 갖는 옵션에 Enum 타입 적용으로 유효성 검사 및 도움말 자동화

### DIFF
--- a/Data/Reportformatter.cs
+++ b/Data/Reportformatter.cs
@@ -6,6 +6,10 @@ using RepoScore.Services;
 
 namespace RepoScore.Data
 {
+    public enum OutputFormat { Csv, Txt }
+
+    public enum ClaimsMode { Issue, User }
+
     public static class ReportFormatter
     {
         public static string BuildTextReport(
@@ -93,7 +97,7 @@ namespace RepoScore.Data
             return sb.ToString();
         }
 
-        public static string BuildClaimsReport(ClaimsData data, string mode)
+        public static string BuildClaimsReport(ClaimsData data, ClaimsMode mode)
         {
             var sb = new StringBuilder();
 
@@ -102,7 +106,7 @@ namespace RepoScore.Data
                 return "최근 48시간 내 선점된 이슈가 없습니다.\n";
             }
 
-            if (mode == "user")
+            if (mode == ClaimsMode.User)
             {
                 if (data.UnclaimedUrls.Count > 0)
                 {

--- a/Data/Reportsorter.cs
+++ b/Data/Reportsorter.cs
@@ -3,23 +3,24 @@ using System.Linq;
 
 namespace RepoScore.Data
 {
+    public enum SortBy { Score, Id }
+
+    public enum SortOrder { Asc, Desc }
+
     public static class ReportSorter
     {
         public static List<(string Id, int docIssues, int featBugIssues, int typoPrs, int docPrs, int featBugPrs, int Score)>
         SortReportData(
             List<(string Id, int docIssues, int featBugIssues, int typoPrs, int docPrs, int featBugPrs, int Score)> data,
-            string sortBy,
-            string sortOrder)
+            SortBy sortBy,
+            SortOrder sortOrder)
         {
-            return sortBy.ToLower() switch
+            return sortBy switch
             {
-                "score" => sortOrder.ToLower() == "asc"
-                    ? data.OrderBy(x => x.Score).ToList()
-                    : data.OrderByDescending(x => x.Score).ToList(),
-                "id" => sortOrder.ToLower() == "asc"
+                SortBy.Id => sortOrder == SortOrder.Asc
                     ? data.OrderBy(x => x.Id).ToList()
                     : data.OrderByDescending(x => x.Id).ToList(),
-                _ => sortOrder.ToLower() == "asc"
+                _ => sortOrder == SortOrder.Asc
                     ? data.OrderBy(x => x.Score).ToList()
                     : data.OrderByDescending(x => x.Score).ToList()
             };

--- a/Program.cs
+++ b/Program.cs
@@ -14,24 +14,17 @@ CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo("en-US");
 CoconaApp.Run((
 [Argument(Description = "대상 저장소 목록 (예: owner/repo1 owner/repo2)")] string[] repos,
 [Option('t', Description = "GitHub Token (미입력시 GITHUB_TOKEN 사용)")] string? token = null,
-[Option(Description = "최근 이슈 선점 현황 조회 (issue|user)")] string? claims = null,
-[Option('f', Description = "출력 형식 (csv, txt)")] string format = "csv",
+[Option(Description = "최근 이슈 선점 현황 조회")] ClaimsMode? claims = null,
+[Option('f', Description = "출력 형식")] OutputFormat format = OutputFormat.Csv,
 [Option('o', Description = "출력 디렉토리 경로")] string output = "./results",
-[Option(Description = "정렬 기준 (score | id)")] string sortBy = "score",
-[Option(Description = "정렬 방법 (asc | desc)")] string sortOrder = "desc",
+[Option(Description = "정렬 기준")] SortBy sortBy = SortBy.Score,
+[Option(Description = "정렬 방법")] SortOrder sortOrder = SortOrder.Desc,
 [Option(Description = "이슈 선점 키워드 (쉼표 구분, 미입력시 기본값 사용)")] string? keywords = null,
 [Option(Description = "캐시를 무시하고 전체 데이터를 다시 수집할지 여부")] bool noCache = false
 ) =>
 {
     token ??= Environment.GetEnvironmentVariable("GITHUB_TOKEN");
     if (string.IsNullOrEmpty(token)) { Console.Error.WriteLine("오류: GitHub 토큰이 필요합니다."); return; }
-
-    var allowedFormats = new[] { "csv", "txt" };
-    if (!allowedFormats.Contains(format.ToLowerInvariant()))
-    {
-        Console.Error.WriteLine($"오류: 지원하지 않는 형식입니다. csv 또는 txt를 입력해 주세요. (입력값: {format})");
-        return;
-    }
 
     string[]? parsedKeywords = keywords != null
         ? keywords.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
@@ -63,10 +56,9 @@ CoconaApp.Run((
             if (claims != null)
             {
                 AnsiConsole.MarkupLine($"[[[blue]{ownerName}/{repoName}[/]]] 최근 이슈 선점 현황을 조회합니다...\n");
-                var mode = string.IsNullOrEmpty(claims) ? "issue" : claims;
 
                 var claimsData = service.GetRecentClaimsData();
-                var report = ReportFormatter.BuildClaimsReport(claimsData, mode);
+                var report = ReportFormatter.BuildClaimsReport(claimsData, claims.Value);
                 Console.Write(report);
                 continue;
             }
@@ -194,7 +186,7 @@ CoconaApp.Run((
             Console.Error.WriteLine($"기본 데이터(CSV) 저장 완료: {csvPath}");
 
             // TXT 리포트 생성
-            if (format.ToLower() == "txt")
+            if (format == OutputFormat.Txt)
             {
                 string txtPath = Path.Combine(repoOutput, "results.txt");
                 string txtContent = ReportFormatter.BuildTextReport(repo, reportData);
@@ -250,7 +242,7 @@ CoconaApp.Run((
             Console.Error.WriteLine($"전체 합산 데이터(CSV) 저장 완료: {totalCsvPath}");
 
             // 합산 TXT
-            if (format.ToLower() == "txt")
+            if (format == OutputFormat.Txt)
             {
                 string totalLabel = string.Join(" + ", repos);
                 string totalTxtPath = Path.Combine(totalOutput, "results.txt");

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ dotnet run -- --help
 <!-- synopsis:start -->
 
 ```text
-Usage: reposcore-cs [--token <String>] [--claims <String>] [--format <String>] [--output <String>] [--sort-by <String>] [--sort-order <String>] [--keywords <String>] [--no-cache] [--help] [--version] repos0 ... reposN
+Usage: reposcore-cs [--token <String>] [--claims <ClaimsMode>] [--format <OutputFormat>] [--output <String>] [--sort-by <SortBy>] [--sort-order <SortOrder>] [--keywords <String>] [--no-cache] [--help] [--version] repos0 ... reposN
 
 reposcore-cs
 
@@ -50,16 +50,16 @@ Arguments:
   0: repos    대상 저장소 목록 (예: owner/repo1 owner/repo2) (Required)
 
 Options:
-  -t, --token <String>     GitHub Token (미입력시 GITHUB_TOKEN 사용)
-  --claims <String>        최근 이슈 선점 현황 조회 (issue|user)
-  -f, --format <String>    출력 형식 (csv, txt) (Default: csv)
-  -o, --output <String>    출력 디렉토리 경로 (Default: ./results)
-  --sort-by <String>       정렬 기준 (score | id) (Default: score)
-  --sort-order <String>    정렬 방법 (asc | desc) (Default: desc)
-  --keywords <String>      이슈 선점 키워드 (쉼표 구분, 미입력시 기본값 사용)
-  --no-cache               캐시를 무시하고 전체 데이터를 다시 수집할지 여부
-  -h, --help               Show help message
-  --version                Show version
+  -t, --token <String>           GitHub Token (미입력시 GITHUB_TOKEN 사용)
+  --claims <ClaimsMode>          최근 이슈 선점 현황 조회 (Allowed values: Issue, User)
+  -f, --format <OutputFormat>    출력 형식 (Default: Csv) (Allowed values: Csv, Txt)
+  -o, --output <String>          출력 디렉토리 경로 (Default: ./results)
+  --sort-by <SortBy>             정렬 기준 (Default: Score) (Allowed values: Score, Id)
+  --sort-order <SortOrder>       정렬 방법 (Default: Desc) (Allowed values: Asc, Desc)
+  --keywords <String>            이슈 선점 키워드 (쉼표 구분, 미입력시 기본값 사용)
+  --no-cache                     캐시를 무시하고 전체 데이터를 다시 수집할지 여부
+  -h, --help                     Show help message
+  --version                      Show version
 ```
 
 <!-- synopsis:end -->

--- a/RepoScore.Tests/ReportFormatterTests.cs
+++ b/RepoScore.Tests/ReportFormatterTests.cs
@@ -29,7 +29,7 @@ public class ReportFormatterTests
             }
         };
 
-        string report = ReportFormatter.BuildClaimsReport(data, "repo");
+        string report = ReportFormatter.BuildClaimsReport(data, ClaimsMode.Issue);
 
         Assert.Contains("PR 생성됨 - #393", report);
     }


### PR DESCRIPTION
### ISSUE_ID
Closes https://github.com/oss2026hnu/reposcore-cs/issues/407

### 변경사항
- [x] `--format`, `--sort-by`, `--sort-order`, `--claims` 옵션을 `OutputFormat`, `SortBy`, `SortOrder`, `ClaimsMode` enum으로 교체
- [x] `Program.cs`의 format 수동 유효성 검사 로직 제거 (Cocona가 파싱 단계에서 자동 처리)
- [x] `--help` Description에서 수동 나열했던 허용 값(`(csv, txt)` 등) 제거 (enum 멤버가 자동 표시)
- [x] `ReportSorter.SortReportData`, `ReportFormatter.BuildClaimsReport` 시그니처를 enum으로 변경 및 테스트 갱신

### 🧪 테스트 방법 (선택 사항)
```bash
dotnet build reposcore-cs.sln
dotnet test RepoScore.Tests/RepoScore.Tests.csproj
```
- 빌드 경고/오류 0개, 테스트 43건 모두 통과 확인
- `dotnet run -- <repo> --format wrong` 등 잘못된 값 입력 시 Cocona가 자동으로 오류 메시지 출력
- `dotnet run -- --help` 출력에 enum 멤버가 허용 값으로 자동 표시되는지 확인

### 💬 참고 사항 (선택 사항)
- `docs/cli-options-guide.md`는 사용자 가이드 문서라 본 PR 범위 밖 — 별도 작업으로 분리 권장
