### PR TITLE
claims 옵션 활성화시 점수계산 후 선점 이슈 출력하도록 로직 수정

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -60,17 +60,6 @@ CoconaApp.Run((
 
         try
         {
-            if (claims != null)
-            {
-                AnsiConsole.MarkupLine($"[[[blue]{ownerName}/{repoName}[/]]] 최근 이슈 선점 현황을 조회합니다...\n");
-                var mode = string.IsNullOrEmpty(claims) ? "issue" : claims;
-
-                var claimsData = service.GetRecentClaimsData();
-                var report = ReportFormatter.BuildClaimsReport(claimsData, mode);
-                Console.Write(report);
-                continue;
-            }
-
             AnsiConsole.MarkupLine($"[yellow]{repo}[/] 기여자 데이터 수집 및 분석 중...");
 
             if (!Directory.Exists(repoOutput)) Directory.CreateDirectory(repoOutput);
@@ -217,8 +206,8 @@ CoconaApp.Run((
         }
     }
 
-    // 저장소가 2개 이상이고 claims 모드가 아닐 때만 전체 합산 리포트 생성
-    if (repos.Length > 1 && claims == null && (totalUserIssues.Count > 0 || totalUserPullRequests.Count > 0))
+    // 저장소가 1개 이상일 때 전체 합산 리포트 생성
+    if (repos.Length > 1 && (totalUserIssues.Count > 0 || totalUserPullRequests.Count > 0))
     {
         try
         {
@@ -281,6 +270,34 @@ CoconaApp.Run((
         catch (Exception ex)
         {
             AnsiConsole.WriteException(ex);
+        }
+    }
+
+    // 모든 점수 계산 및 리포트 출력이 끝난 후, 이슈 선점 현황을 일괄 조회 및 출력
+    if (claims != null)
+    {
+        foreach (var repo in repos)
+        {
+            var parts = repo.Split('/');
+            if (parts.Length != 2) continue; // 포맷 오류는 위쪽 점수 계산 루프에서 이미 경고됨
+
+            string ownerName = parts[0];
+            string repoName = parts[1];
+            var service = new GitHubService(ownerName, repoName, token, parsedKeywords);
+
+            try
+            {
+                AnsiConsole.MarkupLine($"\n[[[blue]{ownerName}/{repoName}[/]]] 최근 이슈 선점 현황을 조회합니다...\n");
+                var mode = string.IsNullOrEmpty(claims) ? "issue" : claims;
+
+                var claimsData = service.GetRecentClaimsData();
+                var report = ReportFormatter.BuildClaimsReport(claimsData, mode);
+                Console.Write(report);
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.WriteException(ex);
+            }
         }
     }
 });


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #415

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- [ ] claims 옵션 활성화시 점수계산 후 선점 이슈 출력하도록 로직 수정

### 🧪 테스트 방법 (선택 사항)
dotnet run -- oss2026hnu/reposcore-cs oss2026hnu/reposcore-ts --token {토큰} --claims=

위 명령어를 실행하여 정상동작하는지 확인

### 💬 참고 사항 (선택 사항)
<!-- 리뷰 시 참고해야 할 내용이나 전달하고 싶은 사항이 있다면 작성해주세요 -->
