### PR TITLE
Implement incremental retrieval and cumulative caching for claims data

### DIFF
--- a/Services/GitHubService.cs
+++ b/Services/GitHubService.cs
@@ -254,20 +254,20 @@ namespace RepoScore.Services
 
         // 저장소의 열린 이슈를 대상으로 최근 48시간 내 선점 현황을 조회.
         // 이슈별로 선점 댓글 작성자, 남은 기한, 연결된 PR 유무를 파악하여 반환.
-        public ClaimsData GetRecentClaimsData()
+        public ClaimsData GetRecentClaimsData(DateTimeOffset? since = null)
         {
             var claimsData = new ClaimsData();
             string? cursor = null;
             bool hasNextPage = true;
             var now = DateTimeOffset.UtcNow;
 
-            List<PRWithLinkedIssues> openPrs = GetOpenPullRequestsWithLinkedIssues();
+            List<PRWithLinkedIssues> openPrs = GetOpenPullRequestsWithLinkedIssues(since);
 
             while (hasNextPage)
             {
                 var query = new Octokit.GraphQL.Query()
                     .Repository(_repo, _owner)
-                    .Issues(first: 100, after: cursor, states: new[] { IssueState.Open }, orderBy: new IssueOrder { Field = IssueOrderField.CreatedAt, Direction = OrderDirection.Desc })
+                    .Issues(first: 100, after: cursor, states: new[] { IssueState.Open }, since: since, orderBy: new IssueOrder { Field = IssueOrderField.CreatedAt, Direction = OrderDirection.Desc })
                     .Select(s => new
                     {
                         s.PageInfo.HasNextPage,
@@ -284,6 +284,10 @@ namespace RepoScore.Services
                                 c.CreatedAt,
                                 AuthorLogin = c.Author.Login
                             }).ToList()
+                            TimelineItems = issue.TimelineItems(first: 10, itemTypes: new[] { IssueTimelineItemsItemType.CrossReferencedEvent }).Nodes.Select(t => new
+                            {
+                                Source = t
+                            }).ToList(),
                         }).ToList()
                     });
 

--- a/Services/GitHubService.cs
+++ b/Services/GitHubService.cs
@@ -284,7 +284,7 @@ namespace RepoScore.Services
                                 c.CreatedAt,
                                 AuthorLogin = c.Author.Login
                             }).ToList(),
-                            TimelineItems = issue.TimelineItems(10, itemTypes: new[] { IssueTimelineItemsItemType.CrossReferencedEvent }).Nodes.Select(t => new
+                            TimelineItems = issue.TimelineItems(10, null, null, null, new[] { IssueTimelineItemsItemType.CrossReferencedEvent }).Nodes.Select(t => new
                             {
                                 Source = t
                             }).ToList(),

--- a/Services/GitHubService.cs
+++ b/Services/GitHubService.cs
@@ -261,7 +261,7 @@ namespace RepoScore.Services
             bool hasNextPage = true;
             var now = DateTimeOffset.UtcNow;
 
-            List<PRWithLinkedIssues> openPrs = GetOpenPullRequestsWithLinkedIssues();
+            List<PRWithLinkedIssues> openPrs = GetOpenPullRequestsWithLinkedIssues(since);
 
             while (hasNextPage)
             {
@@ -300,7 +300,7 @@ namespace RepoScore.Services
 
                     foreach (var comment in issue.Comments)
                     {
-                        if ((now - comment.CreatedAt).TotalHours > 48) continue;
+                        if (comment.CreatedAt < (since ?? now.AddHours(-48))) continue;
 
                         var login = comment.AuthorLogin ?? "unknown";
 
@@ -341,7 +341,7 @@ namespace RepoScore.Services
             return claimsData;
         }
 
-        public List<PRWithLinkedIssues> GetOpenPullRequestsWithLinkedIssues()
+        public List<PRWithLinkedIssues> GetOpenPullRequestsWithLinkedIssues(DateTimeOffset? since = null)
         {
             var prsWithIssues = new List<PRWithLinkedIssues>();
             string? cursor = null;
@@ -372,6 +372,16 @@ namespace RepoScore.Services
                     });
 
                 var result = _graphQLConnection.Run(query).Result;
+
+                if (since.HasValue)
+                {
+                    result = new
+                    { 
+                        result.HasNextPage,
+                        result.EndCursor,
+                        Items = result.Items.Where(pr => pr.UpdatedAt >= since.Value).ToList()
+                    };
+                }
 
                 foreach (var pr in result.Items)
                 {

--- a/Services/GitHubService.cs
+++ b/Services/GitHubService.cs
@@ -283,7 +283,7 @@ namespace RepoScore.Services
                                 c.Body,
                                 c.CreatedAt,
                                 AuthorLogin = c.Author.Login
-                            }).ToList()
+                            }).ToList(),
                             TimelineItems = issue.TimelineItems(first: 10, itemTypes: new[] { IssueTimelineItemsItemType.CrossReferencedEvent }).Nodes.Select(t => new
                             {
                                 Source = t

--- a/Services/GitHubService.cs
+++ b/Services/GitHubService.cs
@@ -261,13 +261,13 @@ namespace RepoScore.Services
             bool hasNextPage = true;
             var now = DateTimeOffset.UtcNow;
 
-            List<PRWithLinkedIssues> openPrs = GetOpenPullRequestsWithLinkedIssues(since);
+            List<PRWithLinkedIssues> openPrs = GetOpenPullRequestsWithLinkedIssues();
 
             while (hasNextPage)
             {
                 var query = new Octokit.GraphQL.Query()
                     .Repository(_repo, _owner)
-                    .Issues(first: 100, after: cursor, states: new[] { IssueState.Open }, since: since, orderBy: new IssueOrder { Field = IssueOrderField.CreatedAt, Direction = OrderDirection.Desc })
+                    .Issues(first: 100, after: cursor, states: new[] { IssueState.Open }, orderBy: new IssueOrder { Field = IssueOrderField.CreatedAt, Direction = OrderDirection.Desc })
                     .Select(s => new
                     {
                         s.PageInfo.HasNextPage,
@@ -284,7 +284,7 @@ namespace RepoScore.Services
                                 c.CreatedAt,
                                 AuthorLogin = c.Author.Login
                             }).ToList(),
-                            TimelineItems = issue.TimelineItems(first: 10, itemTypes: new[] { IssueTimelineItemsItemType.CrossReferencedEvent }).Nodes.Select(t => new
+                            TimelineItems = issue.TimelineItems(10, itemTypes: new[] { IssueTimelineItemsItemType.CrossReferencedEvent }).Nodes.Select(t => new
                             {
                                 Source = t
                             }).ToList(),

--- a/Services/GitHubService.cs
+++ b/Services/GitHubService.cs
@@ -251,7 +251,7 @@ namespace RepoScore.Services
 
             return issueRecords;
         }
-
+        private ClaimsData _accumulatedClaims = new ClaimsData();
         // 저장소의 열린 이슈를 대상으로 최근 48시간 내 선점 현황을 조회.
         // 이슈별로 선점 댓글 작성자, 남은 기한, 연결된 PR 유무를 파악하여 반환.
         public ClaimsData GetRecentClaimsData(DateTimeOffset? since = null)
@@ -338,7 +338,15 @@ namespace RepoScore.Services
                 cursor = result.EndCursor;
             }
 
-            return claimsData;
+            foreach (var item in claimsData.ClaimedMap)
+            {
+                if (_accumulatedClaims.ClaimedMap.ContainsKey(item.Key))
+                    _accumulatedClaims.ClaimedMap[item.Key].AddRange(item.Value);
+                else
+                    _accumulatedClaims.ClaimedMap[item.Key] = item.Value;
+            }
+
+            return _accumulatedClaims; 
         }
 
         public List<PRWithLinkedIssues> GetOpenPullRequestsWithLinkedIssues(DateTimeOffset? since = null)


### PR DESCRIPTION
Implemented incremental data retrieval and cumulative caching using the since parameter. #414

### ISSUE_ID
Closes #414 

### 변경사항
- [ ] GetRecentClaimsData 증분 조회 및 캐시 로직 구현
- [ ] GetOpenPullRequestsWithLinkedIssues 메서드 최적화

### 🧪 테스트 방법 (선택 사항)
GetRecentClaimsData 호출 시 since 시각 이후의 데이터가 정상적으로 조회되는지 확인
TimelineItems 데이터가 유실 없이 병합되어 반환되는지 확인

### 💬 참고 사항 (선택 사항)
_accumulatedClaims 변수가 캐시 역할