### PR TITLE
Claims 메소드에 캐시 및 증분 조회 적용

### DIFF
--- a/Data/CacheManager.cs
+++ b/Data/CacheManager.cs
@@ -1,4 +1,4 @@
-#using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;

--- a/Data/CacheManager.cs
+++ b/Data/CacheManager.cs
@@ -18,6 +18,16 @@ namespace RepoScore.Data
         public Dictionary<string, List<IssueRecord>> UserIssues { get; set; } = new();
 
         public Dictionary<string, List<PRRecord>> UserPullRequests { get; set; } = new();
+
+        // Claims 조회용 캐시: 열린 이슈 목록 (CachedClaimComments 포함)
+        // --claims 옵션 실행 시 증분 갱신에 활용됨
+        public List<IssueRecord> CachedOpenIssues { get; set; } = new();
+
+        // Claims 조회용 캐시: 열린 PR 목록 (LinkedIssueNumbers 포함)
+        public List<PRRecord> CachedOpenPrs { get; set; } = new();
+
+        // Claims 캐시의 마지막 갱신 시각 (--claims 전용, LastAnalyzedAt과 별도 관리)
+        public DateTimeOffset LastClaimsAnalyzedAt { get; set; } = DateTimeOffset.MinValue;
     }
 
     // 캐시 파일의 로드 및 저장을 담당하는 클래스.
@@ -74,6 +84,28 @@ namespace RepoScore.Data
 
             cacheData.LastAnalyzedAt = DateTimeOffset.UtcNow;
             cacheData.Keywords = keywords;
+
+            string json = JsonSerializer.Serialize(cacheData, s_jsonOptions);
+            File.WriteAllText(cacheFilePath, json);
+        }
+
+        // Claims 캐시(열린 이슈/PR)를 캐시 파일에 저장.
+        // LastAnalyzedAt은 건드리지 않고 LastClaimsAnalyzedAt만 갱신.
+        public static void SaveClaimsCache(
+            string cacheFilePath,
+            RepoCache cacheData,
+            List<IssueRecord> openIssues,
+            List<PRRecord> openPrs)
+        {
+            var dir = Path.GetDirectoryName(cacheFilePath);
+            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            {
+                Directory.CreateDirectory(dir);
+            }
+
+            cacheData.CachedOpenIssues = openIssues;
+            cacheData.CachedOpenPrs = openPrs;
+            cacheData.LastClaimsAnalyzedAt = DateTimeOffset.UtcNow;
 
             string json = JsonSerializer.Serialize(cacheData, s_jsonOptions);
             File.WriteAllText(cacheFilePath, json);

--- a/Data/CacheManager.cs
+++ b/Data/CacheManager.cs
@@ -1,4 +1,4 @@
-using System;
+#using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;

--- a/Program.cs
+++ b/Program.cs
@@ -53,13 +53,35 @@ CoconaApp.Run((
 
         try
         {
+            // ── Claims 전용 모드 ──────────────────────────────────────────────────
             if (claims != null)
             {
                 AnsiConsole.MarkupLine($"[[[blue]{ownerName}/{repoName}[/]]] 최근 이슈 선점 현황을 조회합니다...\n");
 
-                var claimsData = service.GetRecentClaimsData();
+                // noCache면 전체 재조회, 아니면 LastClaimsAnalyzedAt 기준 증분 조회
+                DateTimeOffset? claimsSince = (!noCache && cache.LastClaimsAnalyzedAt != DateTimeOffset.MinValue)
+                    ? cache.LastClaimsAnalyzedAt
+                    : (DateTimeOffset?)null;
+
+                if (claimsSince.HasValue)
+                    Console.Error.WriteLine($"Claims 캐시 존재: {claimsSince.Value.ToLocalTime():yyyy-MM-dd HH:mm} — 이후 변경분만 재조회합니다.");
+                else
+                    Console.Error.WriteLine("Claims 캐시 없음: 전체 데이터를 수집합니다.");
+
+                var cachedOpenIssues = cache.CachedOpenIssues.Count > 0 ? cache.CachedOpenIssues : null;
+                var cachedOpenPrs = cache.CachedOpenPrs.Count > 0 ? cache.CachedOpenPrs : null;
+
+                // GetRecentClaimsData가 조회 + 캐시 갱신 데이터를 한 번에 반환
+                // → 추가 API 호출 없이 캐시 저장 가능
+                var (claimsData, updatedOpenIssues, updatedOpenPrs) = service.GetRecentClaimsData(
+                    cachedOpenIssues, cachedOpenPrs, claimsSince);
+
                 var report = ReportFormatter.BuildClaimsReport(claimsData, (ClaimsMode)claims);
                 Console.Write(report);
+
+                CacheManager.SaveClaimsCache(cachePath, cache, updatedOpenIssues, updatedOpenPrs);
+                Console.Error.WriteLine($"Claims 캐시 갱신 완료: {cachePath}");
+
                 continue;
             }
 
@@ -273,32 +295,6 @@ CoconaApp.Run((
         catch (Exception ex)
         {
             AnsiConsole.WriteException(ex);
-        }
-    }
-
-    // 모든 점수 계산 및 리포트 출력이 끝난 후, 이슈 선점 현황을 일괄 조회 및 출력
-    if (claims != null)
-    {
-        foreach (var repo in repos)
-        {
-            var parts = repo.Split('/');
-            if (parts.Length != 2) continue; // 포맷 오류는 위쪽 점수 계산 루프에서 이미 경고됨
-
-            string ownerName = parts[0];
-            string repoName = parts[1];
-            var service = new GitHubService(ownerName, repoName, token, parsedKeywords);
-
-            try
-            {
-                AnsiConsole.MarkupLine($"\n[[[blue]{ownerName}/{repoName}[/]]] 최근 이슈 선점 현황을 조회합니다...\n");
-                var claimsData = service.GetRecentClaimsData();
-                var report = ReportFormatter.BuildClaimsReport(claimsData, claims.GetValueOrDefault(ClaimsMode.Issue));
-                Console.Write(report);
-            }
-            catch (Exception ex)
-            {
-                AnsiConsole.WriteException(ex);
-            }
         }
     }
 });

--- a/Services/GitHubService.cs
+++ b/Services/GitHubService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using Octokit.GraphQL;
 using Octokit.GraphQL.Model;
@@ -22,6 +23,13 @@ namespace RepoScore.Services
         NotPlanned
     }
 
+    // 선점 댓글 정보를 캐시하기 위한 레코드
+    public class ClaimComment
+    {
+        public string AuthorLogin { get; set; } = string.Empty;
+        public DateTimeOffset CreatedAt { get; set; }
+    }
+
     public class IssueRecord
     {
         public int Number { get; set; }
@@ -34,6 +42,12 @@ namespace RepoScore.Services
         public TimeSpan Remaining { get; set; }
         public List<GitHubIssuePrLabel> Labels { get; set; } = new();
         public DateTimeOffset UpdatedAt { get; set; }
+
+        // 캐시용: 최근 48시간 내 선점 키워드가 포함된 댓글 목록.
+        // null이면 캐시 미보유, 빈 리스트면 선점 댓글 없음을 의미.
+        // null일 때 직렬화 생략 → 기여도 분석 캐시(UserIssues)의 크기에 영향 없음.
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public List<ClaimComment>? CachedClaimComments { get; set; } = null;
     }
 
     public class ClaimsData
@@ -51,6 +65,11 @@ namespace RepoScore.Services
         public bool IsMerged { get; set; } = false;
         public List<GitHubIssuePrLabel> Labels { get; set; } = new();
         public DateTimeOffset UpdatedAt { get; set; }
+
+        // Claims 캐시용: PR에 연결된 이슈 번호 목록.
+        // 빈 리스트일 때 직렬화 생략 → 기여도 분석 캐시(UserPullRequests)의 크기에 영향 없음.
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public List<int> LinkedIssueNumbers { get; set; } = new();
     }
 
     public class PRWithLinkedIssues
@@ -253,21 +272,195 @@ namespace RepoScore.Services
         }
 
         // 저장소의 열린 이슈를 대상으로 최근 48시간 내 선점 현황을 조회.
-        // 이슈별로 선점 댓글 작성자, 남은 기한, 연결된 PR 유무를 파악하여 반환.
-        public ClaimsData GetRecentClaimsData()
+        //
+        // cachedOpenIssues: 이전 실행에서 캐시된 열린 이슈 목록 (CachedClaimComments 포함).
+        // cachedOpenPrs:    이전 실행에서 캐시된 열린 PR 목록 (LinkedIssueNumbers 포함).
+        // since: 마지막 Claims 캐시 갱신 시각. 이 시각 이후 업데이트된 항목만 재조회.
+        //
+        // API 호출을 최소화하기 위해 갱신된 이슈/PR을 함께 반환.
+        // 호출 측에서 반환값을 SaveClaimsCache에 그대로 전달하면 추가 API 호출 없이 캐시 저장 가능.
+        public (ClaimsData claimsData, List<IssueRecord> updatedOpenIssues, List<PRRecord> updatedOpenPrs)
+            GetRecentClaimsData(
+                List<IssueRecord>? cachedOpenIssues = null,
+                List<PRRecord>? cachedOpenPrs = null,
+                DateTimeOffset? since = null)
         {
+            var now = DateTimeOffset.UtcNow;
+            bool isFullRefresh = since == null || (now - since.Value).TotalHours > 48;
+
+            // ── 1. 열린 PR 갱신 (API 호출 1회) ───────────────────────────────────
+            // 전체 재조회면 since=null로 전체를 가져오고, 증분이면 since 이후만 가져옴.
+            var freshOpenPrs = GetOpenPullRequestsWithLinkedIssues(isFullRefresh ? null : since);
+
+            List<PRRecord> updatedOpenPrs;
+            if (isFullRefresh || cachedOpenPrs == null)
+            {
+                updatedOpenPrs = freshOpenPrs.Select(p =>
+                {
+                    p.Pr.LinkedIssueNumbers = p.LinkedIssueNumbers;
+                    return p.Pr;
+                }).ToList();
+            }
+            else
+            {
+                // 증분: 캐시에 fresh 결과를 병합
+                updatedOpenPrs = new List<PRRecord>(cachedOpenPrs);
+                foreach (var freshPrWithLinks in freshOpenPrs)
+                {
+                    var freshPr = freshPrWithLinks.Pr;
+                    freshPr.LinkedIssueNumbers = freshPrWithLinks.LinkedIssueNumbers;
+                    int idx = updatedOpenPrs.FindIndex(p => p.Number == freshPr.Number);
+                    if (idx >= 0)
+                        updatedOpenPrs[idx] = freshPr;
+                    else
+                        updatedOpenPrs.Add(freshPr);
+                }
+            }
+
+            // ── 2. 열린 이슈 갱신 (API 호출 1회) ─────────────────────────────────
+            var (freshIssues, closedIssueNumbers) = FetchOpenIssuesWithClaimComments(
+                isFullRefresh ? null : since);
+
+            List<IssueRecord> updatedOpenIssues;
+            if (isFullRefresh || cachedOpenIssues == null)
+            {
+                // 전체 재조회: fresh 결과가 현재 열린 이슈 전체
+                updatedOpenIssues = freshIssues;
+            }
+            else
+            {
+                // 증분: 캐시에 병합하고, since 이후 닫힌 이슈는 제거
+                var openIssueDict = cachedOpenIssues.ToDictionary(i => i.Number);
+                foreach (var freshIssue in freshIssues)
+                    openIssueDict[freshIssue.Number] = freshIssue;
+                foreach (var closedNumber in closedIssueNumbers)
+                    openIssueDict.Remove(closedNumber);
+                updatedOpenIssues = openIssueDict.Values.ToList();
+            }
+
+            // ── 3. Claims 판단 ────────────────────────────────────────────────────
             var claimsData = new ClaimsData();
+
+            foreach (var issue in updatedOpenIssues)
+            {
+                var issueLabels = issue.Labels;
+                var comments = issue.CachedClaimComments ?? new List<ClaimComment>();
+                bool isClaimed = false;
+
+                foreach (var comment in comments)
+                {
+                    if ((now - comment.CreatedAt).TotalHours > 48) continue;
+
+                    var login = comment.AuthorLogin;
+                    var deadlineHours = IsDocumentTask(issueLabels) ? 24.0 : 48.0;
+                    var remaining = comment.CreatedAt.AddHours(deadlineHours) - now;
+
+                    var linkedPrs = updatedOpenPrs
+                        .Where(pr => pr.LinkedIssueNumbers.Contains(issue.Number))
+                        .ToList();
+
+                    if (!claimsData.ClaimedMap.ContainsKey(login))
+                        claimsData.ClaimedMap[login] = new List<IssueRecord>();
+
+                    claimsData.ClaimedMap[login].Add(new IssueRecord
+                    {
+                        Number = issue.Number,
+                        Url = issue.Url,
+                        HasPr = linkedPrs.Count > 0,
+                        LinkedPullRequests = linkedPrs,
+                        Remaining = remaining,
+                        Labels = issueLabels
+                    });
+                    isClaimed = true;
+                    break;
+                }
+
+                if (!isClaimed)
+                    claimsData.UnclaimedUrls.Add(issue.Url);
+            }
+
+            return (claimsData, updatedOpenIssues, updatedOpenPrs);
+        }
+
+        // 열린 이슈와 선점 댓글을 함께 조회.
+        // since가 있으면 해당 시각 이후 업데이트된 이슈만 가져옴.
+        //
+        // 반환: (열린 이슈 목록, since 이후 닫힌 이슈 번호 집합)
+        // 닫힌 이슈 번호 집합: since 이후 업데이트된 이슈를 별도 쿼리로 조회하여
+        //                      열린 이슈 목록에 없는 번호를 닫힌 것으로 판단.
+        private (List<IssueRecord> openIssues, HashSet<int> closedIssueNumbers)
+            FetchOpenIssuesWithClaimComments(DateTimeOffset? since = null)
+        {
+            var openIssues = new List<IssueRecord>();
+            var closedIssueNumbers = new HashSet<int>();
             string? cursor = null;
             bool hasNextPage = true;
             var now = DateTimeOffset.UtcNow;
 
-            List<PRWithLinkedIssues> openPrs = GetOpenPullRequestsWithLinkedIssues();
+            // since 이후 업데이트된 이슈 번호 전체 (열린 것 + 닫힌 것) 수집용
+            // → 열린 이슈 조회 결과와 비교해 닫힌 이슈를 판별
+            var updatedIssueNumbers = new HashSet<int>();
+            if (since.HasValue)
+            {
+                // 검색 API로 since 이후 업데이트된 모든 이슈 번호 수집 (열림/닫힘 구분 없음)
+                const string allIssuesQuery = @"
+                query($searchQuery: String!, $after: String) {
+                    search(query: $searchQuery, type: ISSUE, first: 100, after: $after) {
+                        pageInfo { hasNextPage endCursor }
+                        nodes {
+                            ... on Issue { number }
+                        }
+                    }
+                }";
 
+                string searchString = $"repo:{_owner}/{_repo} is:issue updated:>={since.Value.ToUniversalTime():yyyy-MM-ddTHH:mm:ssZ}";
+                string? searchCursor = null;
+                bool searchHasNextPage = true;
+
+                while (searchHasNextPage)
+                {
+                    var payload = JsonSerializer.Serialize(new
+                    {
+                        query = allIssuesQuery,
+                        variables = new Dictionary<string, object>
+                        {
+                            ["searchQuery"] = searchString,
+                            ["after"] = searchCursor!
+                        }
+                    });
+
+                    var rawResponse = _graphQLConnection.Run(payload).Result;
+                    using var doc = JsonDocument.Parse(rawResponse);
+
+                    if (!doc.RootElement.TryGetProperty("data", out var dataEl) ||
+                        !dataEl.TryGetProperty("search", out var searchEl))
+                        break;
+
+                    var pageInfo = searchEl.GetProperty("pageInfo");
+                    searchHasNextPage = pageInfo.GetProperty("hasNextPage").GetBoolean();
+                    searchCursor = pageInfo.GetProperty("endCursor").GetString();
+
+                    if (searchEl.TryGetProperty("nodes", out var nodes) && nodes.ValueKind == JsonValueKind.Array)
+                    {
+                        foreach (var node in nodes.EnumerateArray())
+                        {
+                            if (node.TryGetProperty("number", out var numEl))
+                                updatedIssueNumbers.Add(numEl.GetInt32());
+                        }
+                    }
+                }
+            }
+
+            // 열린 이슈 + 댓글 조회
             while (hasNextPage)
             {
                 var query = new Octokit.GraphQL.Query()
                     .Repository(_repo, _owner)
-                    .Issues(first: 100, after: cursor, states: new[] { IssueState.Open }, orderBy: new IssueOrder { Field = IssueOrderField.CreatedAt, Direction = OrderDirection.Desc })
+                    .Issues(
+                        first: 100,
+                        after: cursor,
+                        states: new[] { IssueState.Open },
+                        orderBy: new IssueOrder { Field = IssueOrderField.UpdatedAt, Direction = OrderDirection.Desc })
                     .Select(s => new
                     {
                         s.PageInfo.HasNextPage,
@@ -276,7 +469,7 @@ namespace RepoScore.Services
                         {
                             issue.Number,
                             issue.Url,
-
+                            issue.UpdatedAt,
                             Labels = issue.Labels(10, null, null, null, null).Nodes.Select(l => l.Name).ToList(),
                             Comments = issue.Comments(10, null, null, null, null).Nodes.Select(c => new
                             {
@@ -291,59 +484,65 @@ namespace RepoScore.Services
 
                 foreach (var issue in result.Items)
                 {
-                    var issueLabels = issue.Labels.Select(ParseGitHubLabel).Where(l => l != GitHubIssuePrLabel.None).ToList();
-                    var isClaimed = false;
-
-                    foreach (var comment in issue.Comments)
+                    // UpdatedAt 내림차순이므로 since 이전 항목이 나오면 조기 종료
+                    if (since.HasValue && issue.UpdatedAt < since.Value)
                     {
-                        if ((now - comment.CreatedAt).TotalHours > 48) continue;
-
-                        var login = comment.AuthorLogin ?? "unknown";
-
-                        if (_claimKeywords.Any(k => comment.Body.Contains(k, StringComparison.OrdinalIgnoreCase)))
-                        {
-                            var deadlineHours = IsDocumentTask(issueLabels) ? 24.0 : 48.0;
-                            var remaining = comment.CreatedAt.AddHours(deadlineHours) - now;
-                            var linkedPrs = openPrs
-                                .Where(pr => pr.LinkedIssueNumbers.Contains(issue.Number))
-                                .Select(pr => pr.Pr)
-                                .ToList();
-                            var hasPr = linkedPrs.Count > 0;
-
-                            if (!claimsData.ClaimedMap.ContainsKey(login))
-                                claimsData.ClaimedMap[login] = new List<IssueRecord>();
-
-                            claimsData.ClaimedMap[login].Add(new IssueRecord
-                            {
-                                Number = issue.Number,
-                                Url = issue.Url,
-                                HasPr = hasPr,
-                                LinkedPullRequests = linkedPrs,
-                                Remaining = remaining,
-                                Labels = issueLabels
-                            });
-                            isClaimed = true;
-                            break;
-                        }
+                        hasNextPage = false;
+                        break;
                     }
 
-                    if (!isClaimed) claimsData.UnclaimedUrls.Add(issue.Url);
+                    var issueLabels = issue.Labels
+                        .Select(ParseGitHubLabel)
+                        .Where(l => l != GitHubIssuePrLabel.None)
+                        .ToList();
+
+                    var claimComments = issue.Comments
+                        .Where(c => (now - c.CreatedAt).TotalHours <= 48
+                            && _claimKeywords.Any(k => c.Body.Contains(k, StringComparison.OrdinalIgnoreCase)))
+                        .Select(c => new ClaimComment
+                        {
+                            AuthorLogin = c.AuthorLogin ?? "unknown",
+                            CreatedAt = c.CreatedAt
+                        })
+                        .ToList();
+
+                    openIssues.Add(new IssueRecord
+                    {
+                        Number = issue.Number,
+                        Url = issue.Url,
+                        Labels = issueLabels,
+                        UpdatedAt = issue.UpdatedAt,
+                        CachedClaimComments = claimComments
+                    });
                 }
 
+                if (!hasNextPage) break;
                 hasNextPage = result.HasNextPage;
                 cursor = result.EndCursor;
             }
 
-            return claimsData;
+            // since 이후 업데이트됐지만 열린 이슈 목록에 없는 것 = 닫힌 이슈
+            if (since.HasValue)
+            {
+                var openNumbers = openIssues.Select(i => i.Number).ToHashSet();
+                foreach (var num in updatedIssueNumbers)
+                {
+                    if (!openNumbers.Contains(num))
+                        closedIssueNumbers.Add(num);
+                }
+            }
+
+            return (openIssues, closedIssueNumbers);
         }
 
-        public List<PRWithLinkedIssues> GetOpenPullRequestsWithLinkedIssues()
+        // since 이후 업데이트된 열린 PR과 본문에서 파싱한 연결 이슈 번호 목록을 반환.
+        // since가 null이면 전체 열린 PR을 조회.
+        public List<PRWithLinkedIssues> GetOpenPullRequestsWithLinkedIssues(DateTimeOffset? since = null)
         {
             var prsWithIssues = new List<PRWithLinkedIssues>();
             string? cursor = null;
             bool hasNextPage = true;
 
-            // 이슈 번호 파싱을 위한 정규식 (예: #312, URL 해시 제외)
             var regex = new Regex(@"(?<!\w)#(\d+)\b");
 
             while (hasNextPage)
@@ -371,6 +570,9 @@ namespace RepoScore.Services
 
                 foreach (var pr in result.Items)
                 {
+                    if (since.HasValue && pr.UpdatedAt < since.Value)
+                        continue;
+
                     var linkedIssueNumbers = new HashSet<int>();
 
                     if (!string.IsNullOrWhiteSpace(pr.Body))
@@ -379,9 +581,7 @@ namespace RepoScore.Services
                         foreach (Match match in matches)
                         {
                             if (match.Groups.Count > 1 && int.TryParse(match.Groups[1].Value, out int issueNum))
-                            {
                                 linkedIssueNumbers.Add(issueNum);
-                            }
                         }
                     }
 
@@ -393,7 +593,7 @@ namespace RepoScore.Services
                             Title = pr.Title,
                             Url = pr.Url,
                             AuthorLogin = pr.AuthorLogin ?? "",
-                            IsMerged = false, // Open 상태인 PR들만 필터링했으므로 false
+                            IsMerged = false,
                             UpdatedAt = pr.UpdatedAt,
                             Labels = pr.Labels.Select(ParseGitHubLabel).Where(l => l != GitHubIssuePrLabel.None).ToList()
                         },
@@ -413,8 +613,6 @@ namespace RepoScore.Services
             return issueLabels.Contains(GitHubIssuePrLabel.Documentation) || issueLabels.Contains(GitHubIssuePrLabel.Typo);
         }
 
-        // GitHub 라벨 이름 문자열을 GitHubIssuePrLabel 열거형 값으로 변환.
-        // 대소문자 및 공백/하이픈을 정규화한 뒤 매핑. 알 수 없는 라벨은 None 반환.
         internal static GitHubIssuePrLabel ParseGitHubLabel(string labelName)
         {
             if (string.IsNullOrEmpty(labelName)) return GitHubIssuePrLabel.None;
@@ -437,7 +635,6 @@ namespace RepoScore.Services
             };
         }
 
-        // GraphQL 응답의 이슈 노드에서 닫힌 사유(stateReason)를 파싱하여 열거형으로 반환.
         internal static IssueClosedStateReason ParseIssueClosedStateReason(JsonElement issueNode)
         {
             if (!issueNode.TryGetProperty("stateReason", out var stateReasonElement) ||


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #414 

### 변경사항

`--claims` 옵션 실행 시 매번 열린 이슈와 열린 PR 전체를 재조회하던 문제를 개선합니다.
기존 기여도 분석(`GetIssues`, `GetPullRequests`)의 캐시/증분 갱신 구조와 동일한 방식을 Claims 조회에도 적용합니다.

- [x] `Data/CacheManager.cs` — `RepoCache`에 Claims 전용 캐시 필드 3개 추가
  - `CachedOpenIssues`: 열린 이슈 목록 (선점 댓글 포함)
  - `CachedOpenPrs`: 열린 PR 목록 (연결 이슈 번호 포함)
  - `LastClaimsAnalyzedAt`: Claims 캐시 마지막 갱신 시각 (`LastAnalyzedAt`과 별도 관리)
  - `SaveClaimsCache()` 메소드 추가 — Claims 캐시만 선택적으로 갱신

- [x] `Services/GitHubService.cs` — Claims 관련 메소드 전면 개선
  - `IssueRecord`에 `CachedClaimComments` 필드 추가 (선점 댓글 캐시, `[JsonIgnore(WhenWritingNull)]`)
  - `PRRecord`에 `LinkedIssueNumbers` 필드 추가 (연결 이슈 번호 캐시, `[JsonIgnore(WhenWritingDefault)]`)
  - `GetRecentClaimsData()` 시그니처 변경: `cachedOpenIssues`, `cachedOpenPrs`, `since` 파라미터 추가, 반환값을 `(ClaimsData, List<IssueRecord>, List<PRRecord>)` 튜플로 변경하여 API 호출 결과를 캐시 저장까지 재사용
  - `FetchOpenIssuesWithClaimComments()` private 메소드 신설 — 선점 댓글 필터링 후 이슈와 함께 반환, `since` 이후 닫힌 이슈 번호도 함께 반환
  - `GetOpenPullRequestsWithLinkedIssues()`에 `since` 파라미터 추가

- [x] `Program.cs` — Claims 모드에서 캐시 활용
  - `--claims` 실행 시 `cache.LastClaimsAnalyzedAt` 기준으로 증분 조회
  - `GetRecentClaimsData()` 반환 튜플을 `SaveClaimsCache()`에 직접 전달 (추가 API 호출 없음)
  - 원본의 루프 하단 중복 claims 조회 블록 제거

### 🧪 테스트 방법

```bash
# 첫 실행 — 전체 조회 후 cache.json에 CachedOpenIssues/Prs 저장 확인
dotnet run -- oss2026hnu/reposcore-cs --claims issue

# 두 번째 실행 — "이후 변경분만 재조회" 메시지 출력 확인
dotnet run -- oss2026hnu/reposcore-cs --claims issue

# 전체 재조회 강제
dotnet run -- oss2026hnu/reposcore-cs --claims issue --no-cache
```