### PR TITLE
Program.cs 인자 형식 검사 오류 처리 개선

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
 using Cocona;
-using Cocona.Help;
 using RepoScore.Data;
 using RepoScore.Services;
 using Spectre.Console;
@@ -12,9 +12,34 @@ using System.Globalization;
 
 CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo("en-US");
 
+// repos 인자가 없으면 Cocona가 자체적으로 에러 처리하므로,
+// 여기서는 repos 형식('owner/repo') 검증만 담당한다.
+// 검증 실패 시: 오류 메시지 일괄 출력 → help 출력(Cocona 내부 렌더러 재사용) → exit code 1.
+var formatErrors = new List<string>();
+var repoArgs = args.Where(a => !a.StartsWith("-")).ToList();
+
+foreach (var repo in repoArgs)
+{
+    var parts = repo.Split('/');
+    if (parts.Length != 2 || string.IsNullOrWhiteSpace(parts[0]) || string.IsNullOrWhiteSpace(parts[1]))
+    {
+        formatErrors.Add($"오류: '{repo}'는 'owner/repo' 형식이 아닙니다.");
+    }
+}
+
+if (formatErrors.Count > 0)
+{
+    foreach (var error in formatErrors)
+    {
+        Console.Error.WriteLine(error);
+    }
+    Console.Error.WriteLine();
+    ShowHelp();
+    Environment.Exit(1);
+    return;
+}
+
 CoconaApp.Run((
-[FromService] ICoconaHelpMessageBuilder helpMessageBuilder,
-[FromService] ICoconaHelpRenderer helpRenderer,
 [Argument(Description = "대상 저장소 목록 (예: owner/repo1 owner/repo2)")] string[] repos,
 [Option('t', Description = "GitHub Token (미입력시 GITHUB_TOKEN 사용)")] string? token = null,
 [Option(Description = "최근 이슈 선점 현황 조회")] ClaimsMode? claims = null,
@@ -26,39 +51,6 @@ CoconaApp.Run((
 [Option(Description = "캐시를 무시하고 전체 데이터를 다시 수집할지 여부")] bool noCache = false
 ) =>
 {
-    // ── 입력값 검증 ────────────────────────────────────────────────────────────
-    // repos 각 항목이 "owner/repo" 형식인지 검사. 형식 오류가 있으면 모두 수집 후 일괄 출력.
-    // (repos가 비어있는 경우는 Cocona가 람다 진입 전에 처리하므로 여기서는 형식만 검사)
-    var formatErrors = new List<string>();
-
-    foreach (var repo in repos)
-    {
-        var parts = repo.Split('/');
-        if (parts.Length != 2 || string.IsNullOrWhiteSpace(parts[0]) || string.IsNullOrWhiteSpace(parts[1]))
-        {
-            formatErrors.Add($"오류: '{repo}'는 'owner/repo' 형식이 아닙니다.");
-        }
-    }
-
-    if (formatErrors.Count > 0)
-    {
-        // 오류 메시지 일괄 출력
-        foreach (var error in formatErrors)
-        {
-            Console.Error.WriteLine(error);
-        }
-
-        // Cocona의 ICoconaHelpMessageBuilder를 통해 help 텍스트를 생성하여 단일 지점에서 출력.
-        // Cocona는 --help 처리 시 ICoconaHelpMessageBuilder.BuildAndRenderHelp()를 내부적으로 사용하며,
-        // 이를 직접 주입받아 재사용함으로써 코드 중복 없이 일관된 help 출력을 보장한다.
-        Console.Error.WriteLine();
-        Console.Error.WriteLine(helpRenderer.Render(helpMessageBuilder.BuildHelp()));
-
-        Environment.Exit(1);
-        return;
-    }
-    // ──────────────────────────────────────────────────────────────────────────
-
     token ??= Environment.GetEnvironmentVariable("GITHUB_TOKEN");
     if (string.IsNullOrEmpty(token)) { Console.Error.WriteLine("오류: GitHub 토큰이 필요합니다."); Environment.Exit(1); return; }
 
@@ -66,13 +58,11 @@ CoconaApp.Run((
         ? keywords.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
         : null;
 
-    // 전체 저장소 합산용 딕셔너리: 유저별 누적 기여 데이터
     var totalUserIssues = new Dictionary<string, List<IssueRecord>>();
     var totalUserPullRequests = new Dictionary<string, List<PRRecord>>();
 
     foreach (var repo in repos)
     {
-        // 형식 검증을 위에서 통과했으므로 여기서는 안전하게 Split 가능
         var parts = repo.Split('/');
         string ownerName = parts[0];
         string repoName = parts[1];
@@ -126,11 +116,9 @@ CoconaApp.Run((
                 Console.Error.WriteLine("기존 캐시 없음: 전체 데이터를 수집합니다.");
             }
 
-            // 모든 PR 데이터를 한 번에 가져와서 루프 내에서 필터링 (N+1 최적화)
             var allNewPrs = service.GetPullRequests(since);
             var allNewIssues = service.GetIssues(since);
 
-            // 새로 조회된 PR과 이슈의 작성자, 기존 캐시의 작성자 목록을 통합하여 유니크한 기여자 목록 생성
             List<string> contributors = allNewPrs.Select(p => p.AuthorLogin)
                 .Concat(allNewIssues.Select(i => i.AuthorLogin))
                 .Concat(cache.UserIssues.Keys)
@@ -179,14 +167,11 @@ CoconaApp.Run((
 
                 reportData.Add((user, docIssues.Count, featureBugIssues.Count, typoPrs.Count, docPrs.Count, featureBugPrs.Count, finalScore));
 
-                // 전체 합산용 누적
                 if (repos.Length > 1)
                 {
                     if (!totalUserIssues.ContainsKey(user)) totalUserIssues[user] = new List<IssueRecord>();
                     if (!totalUserPullRequests.ContainsKey(user)) totalUserPullRequests[user] = new List<PRRecord>();
 
-                    // 저장소별 이슈/PR은 번호가 겹칠 수 있으므로 URL 기준으로 중복 방지
-                    // URL이 비어있는 경우를 대비해 URL이 있으면 URL로, 없으면 Number 기준으로 판별
                     foreach (var issue in cache.UserIssues[user])
                     {
                         bool isDuplicate = string.IsNullOrEmpty(issue.Url)
@@ -211,7 +196,6 @@ CoconaApp.Run((
 
             reportData = ReportSorter.SortReportData(reportData, sortBy, sortOrder);
 
-            // CSV 데이터 파일 생성
             var csv = new StringBuilder();
             csv.AppendLine("아이디, 문서이슈, 버그/기능이슈, 오타PR, 문서PR, 버그/기능PR, 총점");
             foreach (var r in reportData) csv.AppendLine($"{r.Id}, {r.docIssues}, {r.featBugIssues}, {r.typoPrs}, {r.docPrs}, {r.featBugPrs}, {r.Score}");
@@ -220,7 +204,6 @@ CoconaApp.Run((
             File.WriteAllText(csvPath, csv.ToString(), Encoding.UTF8);
             Console.Error.WriteLine($"기본 데이터(CSV) 저장 완료: {csvPath}");
 
-            // TXT 리포트 생성
             if (format == OutputFormat.Txt)
             {
                 string txtPath = Path.Combine(repoOutput, "results.txt");
@@ -229,7 +212,6 @@ CoconaApp.Run((
                 Console.Error.WriteLine($"가독성 리포트(TXT) 추가 저장 완료: {txtPath}");
             }
 
-            // HTML 리포트 생성
             if (format == OutputFormat.Html)
             {
                 string htmlPath = Path.Combine(repoOutput, "results.html");
@@ -244,7 +226,6 @@ CoconaApp.Run((
         }
     }
 
-    // 저장소가 1개 이상일 때 전체 합산 리포트 생성
     if (repos.Length > 1 && (totalUserIssues.Count > 0 || totalUserPullRequests.Count > 0))
     {
         try
@@ -276,7 +257,6 @@ CoconaApp.Run((
             string totalOutput = output;
             if (!Directory.Exists(totalOutput)) Directory.CreateDirectory(totalOutput);
 
-            // 합산 CSV
             var totalCsv = new StringBuilder();
             totalCsv.AppendLine("아이디, 문서이슈, 버그/기능이슈, 오타PR, 문서PR, 버그/기능PR, 총점");
             foreach (var r in totalReportData) totalCsv.AppendLine($"{r.Id}, {r.docIssues}, {r.featBugIssues}, {r.typoPrs}, {r.docPrs}, {r.featBugPrs}, {r.Score}");
@@ -285,7 +265,6 @@ CoconaApp.Run((
             File.WriteAllText(totalCsvPath, totalCsv.ToString(), Encoding.UTF8);
             Console.Error.WriteLine($"전체 합산 데이터(CSV) 저장 완료: {totalCsvPath}");
 
-            // 합산 TXT
             if (format == OutputFormat.Txt)
             {
                 string totalLabel = string.Join(" + ", repos);
@@ -295,7 +274,6 @@ CoconaApp.Run((
                 Console.Error.WriteLine($"전체 합산 리포트(TXT) 저장 완료: {totalTxtPath}");
             }
 
-            // 합산 HTML
             if (format == OutputFormat.Html)
             {
                 string totalLabel = string.Join(" + ", repos);
@@ -311,7 +289,6 @@ CoconaApp.Run((
         }
     }
 
-    // 모든 점수 계산 및 리포트 출력이 끝난 후, 이슈 선점 현황을 일괄 조회 및 출력
     if (claims != null)
     {
         foreach (var repo in repos)
@@ -337,3 +314,35 @@ CoconaApp.Run((
         }
     }
 });
+
+// ── help 출력 헬퍼 ────────────────────────────────────────────────────────────
+// Cocona는 --help 처리 시 내부 ICoconaHelpRenderer를 통해 help 텍스트를 생성하고
+// stdout으로 출력한 뒤 종료한다. 검증 실패 시 현재 어셈블리를 --help로 재실행하여
+// Cocona가 생성한 help 결과를 그대로 stderr로 리디렉션함으로써
+// 코드 중복 없이 단일 지점에서 일관된 help 출력을 보장한다.
+static void ShowHelp()
+{
+    try
+    {
+        string assemblyPath = System.Reflection.Assembly.GetExecutingAssembly().Location;
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = $"\"{assemblyPath}\" --help",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        using var proc = Process.Start(psi);
+        if (proc != null)
+        {
+            string helpText = proc.StandardOutput.ReadToEnd();
+            proc.WaitForExit();
+            Console.Error.Write(helpText);
+        }
+    }
+    catch
+    {
+        Console.Error.WriteLine("도움말을 표시하려면 --help 옵션을 사용하세요.");
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -13,6 +13,8 @@ using System.Globalization;
 CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo("en-US");
 
 CoconaApp.Run((
+[FromService] ICoconaHelpMessageBuilder helpMessageBuilder,
+[FromService] ICoconaHelpRenderer helpRenderer,
 [Argument(Description = "대상 저장소 목록 (예: owner/repo1 owner/repo2)")] string[] repos,
 [Option('t', Description = "GitHub Token (미입력시 GITHUB_TOKEN 사용)")] string? token = null,
 [Option(Description = "최근 이슈 선점 현황 조회")] ClaimsMode? claims = null,
@@ -21,8 +23,7 @@ CoconaApp.Run((
 [Option(Description = "정렬 기준")] SortBy sortBy = SortBy.Score,
 [Option(Description = "정렬 방법")] SortOrder sortOrder = SortOrder.Desc,
 [Option(Description = "이슈 선점 키워드 (쉼표 구분, 미입력시 기본값 사용)")] string? keywords = null,
-[Option(Description = "캐시를 무시하고 전체 데이터를 다시 수집할지 여부")] bool noCache = false,
-[FromService] ICoconaHelpMessageBuilder helpMessageBuilder
+[Option(Description = "캐시를 무시하고 전체 데이터를 다시 수집할지 여부")] bool noCache = false
 ) =>
 {
     // ── 입력값 검증 ────────────────────────────────────────────────────────────
@@ -51,7 +52,7 @@ CoconaApp.Run((
         // Cocona는 --help 처리 시 ICoconaHelpMessageBuilder.BuildAndRenderHelp()를 내부적으로 사용하며,
         // 이를 직접 주입받아 재사용함으로써 코드 중복 없이 일관된 help 출력을 보장한다.
         Console.Error.WriteLine();
-        Console.Error.WriteLine(helpMessageBuilder.BuildAndRenderHelp());
+        Console.Error.WriteLine(helpRenderer.Render(helpMessageBuilder.BuildHelp()));
 
         Environment.Exit(1);
         return;

--- a/Program.cs
+++ b/Program.cs
@@ -16,7 +16,22 @@ CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo("en-US");
 // 여기서는 repos 형식('owner/repo') 검증만 담당한다.
 // 검증 실패 시: 오류 메시지 일괄 출력 → help 출력(Cocona 내부 렌더러 재사용) → exit code 1.
 var formatErrors = new List<string>();
-var repoArgs = args.Where(a => !a.StartsWith("-")).ToList();
+// Cocona의 파라미터 파싱 규칙에 따라 positional argument(repos)는
+// 옵션 플래그(--)나 옵션값과 구분해야 한다.
+// "-"로 시작하지 않고, 바로 앞 인자가 값을 받는 옵션이 아닌 경우만 repo 후보로 간주한다.
+// 가장 안전한 방법: "--" 이후 또는 알려진 옵션 플래그 목록 외의 인자만 추출.
+var knownValueOptions = new HashSet<string> { "-t", "--token", "--claims", "-f", "--format", "-o", "--output", "--sort-by", "--sort-order", "--keywords" };
+var repoArgs = new List<string>();
+for (int i = 0; i < args.Length; i++)
+{
+    if (knownValueOptions.Contains(args[i]))
+    {
+        i++; // 다음 인자는 옵션 값이므로 건너뜀
+        continue;
+    }
+    if (args[i].StartsWith("-")) continue; // 플래그 옵션 건너뜀
+    repoArgs.Add(args[i]);
+}
 
 foreach (var repo in repoArgs)
 {

--- a/Program.cs
+++ b/Program.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using Cocona;
+using Cocona.Help;
 using RepoScore.Data;
 using RepoScore.Services;
 using Spectre.Console;
@@ -20,11 +21,45 @@ CoconaApp.Run((
 [Option(Description = "정렬 기준")] SortBy sortBy = SortBy.Score,
 [Option(Description = "정렬 방법")] SortOrder sortOrder = SortOrder.Desc,
 [Option(Description = "이슈 선점 키워드 (쉼표 구분, 미입력시 기본값 사용)")] string? keywords = null,
-[Option(Description = "캐시를 무시하고 전체 데이터를 다시 수집할지 여부")] bool noCache = false
+[Option(Description = "캐시를 무시하고 전체 데이터를 다시 수집할지 여부")] bool noCache = false,
+[FromService] ICoconaHelpMessageBuilder helpMessageBuilder
 ) =>
 {
+    // ── 입력값 검증 ────────────────────────────────────────────────────────────
+    // repos 각 항목이 "owner/repo" 형식인지 검사. 형식 오류가 있으면 모두 수집 후 일괄 출력.
+    // (repos가 비어있는 경우는 Cocona가 람다 진입 전에 처리하므로 여기서는 형식만 검사)
+    var formatErrors = new List<string>();
+
+    foreach (var repo in repos)
+    {
+        var parts = repo.Split('/');
+        if (parts.Length != 2 || string.IsNullOrWhiteSpace(parts[0]) || string.IsNullOrWhiteSpace(parts[1]))
+        {
+            formatErrors.Add($"오류: '{repo}'는 'owner/repo' 형식이 아닙니다.");
+        }
+    }
+
+    if (formatErrors.Count > 0)
+    {
+        // 오류 메시지 일괄 출력
+        foreach (var error in formatErrors)
+        {
+            Console.Error.WriteLine(error);
+        }
+
+        // Cocona의 ICoconaHelpMessageBuilder를 통해 help 텍스트를 생성하여 단일 지점에서 출력.
+        // Cocona는 --help 처리 시 ICoconaHelpMessageBuilder.BuildAndRenderHelp()를 내부적으로 사용하며,
+        // 이를 직접 주입받아 재사용함으로써 코드 중복 없이 일관된 help 출력을 보장한다.
+        Console.Error.WriteLine();
+        Console.Error.WriteLine(helpMessageBuilder.BuildAndRenderHelp());
+
+        Environment.Exit(1);
+        return;
+    }
+    // ──────────────────────────────────────────────────────────────────────────
+
     token ??= Environment.GetEnvironmentVariable("GITHUB_TOKEN");
-    if (string.IsNullOrEmpty(token)) { Console.Error.WriteLine("오류: GitHub 토큰이 필요합니다."); return; }
+    if (string.IsNullOrEmpty(token)) { Console.Error.WriteLine("오류: GitHub 토큰이 필요합니다."); Environment.Exit(1); return; }
 
     string[]? parsedKeywords = keywords != null
         ? keywords.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
@@ -36,9 +71,8 @@ CoconaApp.Run((
 
     foreach (var repo in repos)
     {
+        // 형식 검증을 위에서 통과했으므로 여기서는 안전하게 Split 가능
         var parts = repo.Split('/');
-        if (parts.Length != 2) { Console.Error.WriteLine($"오류: '{repo}'는 'owner/repo' 형식이 아닙니다. 건너뜁니다."); continue; }
-
         string ownerName = parts[0];
         string repoName = parts[1];
 
@@ -282,7 +316,7 @@ CoconaApp.Run((
         foreach (var repo in repos)
         {
             var parts = repo.Split('/');
-            if (parts.Length != 2) continue; // 포맷 오류는 위쪽 점수 계산 루프에서 이미 경고됨
+            if (parts.Length != 2) continue;
 
             string ownerName = parts[0];
             string repoName = parts[1];


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #416 

### 변경사항
- [x] `owner/repo` 형식이 아닌 `repos` 인자에 대한 형식 검증 추가 (오류 있는 항목 모두 수집 후 일괄 출력)
- [x] 형식 오류 시 Cocona 내부 렌더러가 생성한 help 메시지를 재실행 방식으로 stderr에 출력
- [x] 형식 오류 및 토큰 누락 시 `Environment.Exit(1)`로 비정상 종료(non-zero exit code) 처리
- [x] 옵션 값(`--token`, `--output` 등) 오탐 방지를 위한 `knownValueOptions` 기반 인자 파싱 추가

### 🧪 테스트 방법
```bash
# owner/repo 형식이 아닌 저장소명 → 오류 메시지 + help 출력 + exit code 1 확인
dotnet run -- invalidrepo
echo $?   # 1 이어야 함

# 여러 개 중 일부만 형식 오류 → 오류 있는 항목 모두 출력 확인
dotnet run -- oss2026hnu/reposcore-cs invalidrepo

# 옵션 값 오탐 없는지 확인 (token 값이 repo로 잘못 인식되지 않아야 함)
dotnet run -- invalidrepo --token ghp_xxx
echo $?   # 1 이어야 하고, ghp_xxx 관련 오류는 없어야 함

# 정상 입력은 기존과 동일하게 동작하는지 확인
dotnet run -- oss2026hnu/reposcore-cs
```
