### PR TITLE
존재하지 않는 저장소 입력 시 오류 수정

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -34,10 +34,34 @@ CoconaApp.Run((
     var totalUserIssues = new Dictionary<string, List<IssueRecord>>();
     var totalUserPullRequests = new Dictionary<string, List<PRRecord>>();
 
+    // 모든 저장소 존재 여부를 먼저 검사
     foreach (var repo in repos)
     {
         var parts = repo.Split('/');
-        if (parts.Length != 2) { Console.Error.WriteLine($"오류: '{repo}'는 'owner/repo' 형식이 아닙니다. 건너뜁니다."); continue; }
+
+        if (parts.Length != 2)
+        {
+            Console.Error.WriteLine($"오류: '{repo}'는 'owner/repo' 형식이 아닙니다.");
+            Environment.ExitCode = 1;
+            return;
+        }
+
+        string ownerName = parts[0];
+        string repoName = parts[1];
+
+        var service = new GitHubService(ownerName, repoName, token, parsedKeywords);
+
+        if (!service.RepositoryExists())
+        {
+            Console.Error.WriteLine($"오류: 저장소 '{repo}'가 존재하지 않거나 접근할 수 없습니다.");
+            Environment.ExitCode = 1;
+            return;
+        }
+    }
+
+    foreach (var repo in repos)
+    {
+        var parts = repo.Split('/');
 
         string ownerName = parts[0];
         string repoName = parts[1];

--- a/Services/GitHubService.cs
+++ b/Services/GitHubService.cs
@@ -101,6 +101,27 @@ namespace RepoScore.Services
                 new Octokit.GraphQL.ProductHeaderValue("reposcore-cs"), token);
         }
 
+        public bool RepositoryExists()
+        {
+            try
+            {
+                var query = new Octokit.GraphQL.Query()
+                    .Repository(_repo, _owner)
+                    .Select(r => new
+                    {
+                        r.Name
+                    });
+
+                var result = _graphQLConnection.Run(query).Result;
+
+                return result != null;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
         // 저장소의 머지된 전체 PR 목록을 GraphQL로 조회.
         // since가 지정된 경우 해당 시각 이후 업데이트된 PR만 가져옴.
         public List<PRRecord> GetPullRequests(DateTimeOffset? since = null)


### PR DESCRIPTION
### ISSUE_ID
Closes https://github.com/oss2026hnu/reposcore-cs/issues/422

### 변경사항
- [x] GitHubService.cs 프로그램 실행 전 모든 저장소의 존재 여부를 먼저 검증하도록 사전 검사 로직 추가
- [x] 존재하지 않는 저장소 또는 잘못된 owner/repo 형식 입력 시 오류 메시지 출력 후 비정상 종료 코드(Environment.ExitCode = 1)로 즉시 종료되도록 수정
- [x] Program.cs에 저장소 검증 실패 시 결과 파일 및 전체 합산 리포트가 생성되지 않도록 처리용 루프 이전에 검증 단계 추

### 🧪 테스트 방법 (선택 사항)
- 존재하지 않는 저장소 단독 입력
  - dotnet run -- oss2026hnu/wasd
- 여러 저장소 중 일부만 존재하지 않는 경우
  - dotnet run -- oss2026hnu/reposcore-cs oss2026hnu/wasd
-여러 저장소 모두 존재하지 않는 경우
  - dotnet run -- oss2026hnu/wads oss2026hnu/wasd
- 잘못된 저장소 형식 입력
  -dotnet run -- reposcore-cs

### 💬 참고 사항 (선택 사항)
