### PR TITLE
dotnet-guide.md의 잘못된 CLI 옵션 수정

### DIFF
--- a/docs/dotnet-guide.md
+++ b/docs/dotnet-guide.md
@@ -302,7 +302,7 @@ public class CliExecutionTests
     [Theory]
     [InlineData("--format=txt")]
     [InlineData("--format=csv")]
-    [InlineData("--format=txt --show-claims")]
+    [InlineData("--format=txt --claims=Issue")]
     public async Task Cli_Should_Run_Without_Error(string options)
     {
         var repo = "oss2025hnu/reposcore-cs";


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #427 


### 변경사항
- [x] `docs/dotnet-guide.md` 7.4절 CLI 실행 테스트 예시의 `--show-claims`를 `--claims=Issue`로 수정

### 수정 내용

`docs/dotnet-guide.md` 7.4절 예시 코드에 존재하지 않는 옵션 `--show-claims`가 사용되고 있었습니다.

실제 정의된 옵션은 `--claims <ClaimsMode>`이며, 허용 값은 `Issue` 또는 `User`입니다.
가이드를 그대로 따라 테스트를 작성하면 Cocona가 `Unknown option 'show-claims'` 오류를 던지고 `Assert.True(process.ExitCode == 0, error)`가 실패하게 됩니다.

**변경 전:**
```csharp
[InlineData("--format=txt --show-claims")]
```

**변경 후:**
```csharp
[InlineData("--format=txt --claims=Issue")]
```