### PR TITLE
refactor: ShowHelp() 프로세스 재실행 방식을 CommandExitedException으로 대체

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -11,41 +10,6 @@ using Spectre.Console;
 using System.Globalization;
 
 CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo("en-US");
-
-var formatErrors = new List<string>();
-var knownValueOptions = new HashSet<string> { "-t", "--token", "--claims", "-f", "--format", "-o", "--output", "--sort-by", "--sort-order", "--keywords" };
-var repoArgs = new List<string>();
-for (int i = 0; i < args.Length; i++)
-{
-    if (knownValueOptions.Contains(args[i]))
-    {
-        i++;
-        continue;
-    }
-    if (args[i].StartsWith("-")) continue;
-    repoArgs.Add(args[i]);
-}
-
-foreach (var repo in repoArgs)
-{
-    var parts = repo.Split('/');
-    if (parts.Length != 2 || string.IsNullOrWhiteSpace(parts[0]) || string.IsNullOrWhiteSpace(parts[1]))
-    {
-        formatErrors.Add($"오류: '{repo}'는 'owner/repo' 형식이 아닙니다.");
-    }
-}
-
-if (formatErrors.Count > 0)
-{
-    foreach (var error in formatErrors)
-    {
-        Console.Error.WriteLine(error);
-    }
-    Console.Error.WriteLine();
-    ShowHelp();
-    Environment.Exit(1);
-    return;
-}
 
 CoconaApp.Run((
 [Argument(Description = "대상 저장소 목록 (예: owner/repo1 owner/repo2)")] string[] repos,
@@ -59,8 +23,36 @@ CoconaApp.Run((
 [Option(Description = "캐시를 무시하고 전체 데이터를 다시 수집할지 여부")] bool noCache = false
 ) =>
 {
+    void PrintHelp()
+    {
+    Console.Error.WriteLine("도움말을 보려면 --help 옵션을 사용하세요.");
+    }
+    
+    var formatErrors = new List<string>();
+    foreach (var repo in repos)
+    {
+        var parts = repo.Split('/');
+        if (parts.Length != 2 || string.IsNullOrWhiteSpace(parts[0]) || string.IsNullOrWhiteSpace(parts[1]))
+            formatErrors.Add($"오류: '{repo}'는 'owner/repo' 형식이 아닙니다.");
+    }
+
+    if (formatErrors.Count > 0)
+    {
+        foreach (var error in formatErrors)
+            Console.Error.WriteLine(error);
+        Console.Error.WriteLine();
+        PrintHelp();
+        throw new CommandExitedException(1);
+    }
+
     token ??= Environment.GetEnvironmentVariable("GITHUB_TOKEN");
-    if (string.IsNullOrEmpty(token)) { Console.Error.WriteLine("오류: GitHub 토큰이 필요합니다."); Environment.Exit(1); return; }
+    if (string.IsNullOrEmpty(token))
+    {
+        Console.Error.WriteLine("오류: GitHub 토큰이 필요합니다.");
+        Console.Error.WriteLine();
+        PrintHelp();
+        throw new CommandExitedException(1);
+    }
 
     string[]? parsedKeywords = keywords != null
         ? keywords.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
@@ -324,30 +316,3 @@ CoconaApp.Run((
         }
     }
 });
-
-static void ShowHelp()
-{
-    try
-    {
-        string assemblyPath = System.Reflection.Assembly.GetExecutingAssembly().Location;
-        var psi = new ProcessStartInfo
-        {
-            FileName = "dotnet",
-            Arguments = $"\"{assemblyPath}\" --help",
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-        };
-        using var proc = Process.Start(psi);
-        if (proc != null)
-        {
-            string helpText = proc.StandardOutput.ReadToEnd();
-            proc.WaitForExit();
-            Console.Error.Write(helpText);
-        }
-    }
-    catch
-    {
-        Console.Error.WriteLine("도움말을 표시하려면 --help 옵션을 사용하세요.");
-    }
-}

--- a/Program.cs
+++ b/Program.cs
@@ -22,12 +22,7 @@ CoconaApp.Run((
 [Option(Description = "이슈 선점 키워드 (쉼표 구분, 미입력시 기본값 사용)")] string? keywords = null,
 [Option(Description = "캐시를 무시하고 전체 데이터를 다시 수집할지 여부")] bool noCache = false
 ) =>
-{
-    void PrintHelp()
-    {
-    Console.Error.WriteLine("도움말을 보려면 --help 옵션을 사용하세요.");
-    }
-    
+{   
     var formatErrors = new List<string>();
     foreach (var repo in repos)
     {
@@ -41,7 +36,7 @@ CoconaApp.Run((
         foreach (var error in formatErrors)
             Console.Error.WriteLine(error);
         Console.Error.WriteLine();
-        PrintHelp();
+        Console.Error.WriteLine("도움말을 보려면 --help 옵션을 사용하세요.");
         throw new CommandExitedException(1);
     }
 
@@ -50,7 +45,7 @@ CoconaApp.Run((
     {
         Console.Error.WriteLine("오류: GitHub 토큰이 필요합니다.");
         Console.Error.WriteLine();
-        PrintHelp();
+        Console.Error.WriteLine("도움말을 보려면 --help 옵션을 사용하세요.");
         throw new CommandExitedException(1);
     }
 


### PR DESCRIPTION
### ISSUE_ID
Closes #430

### 변경사항
- [x] `using System.Diagnostics` 및 `static void ShowHelp()` 제거
- [x] `CoconaApp.Run` 이전 args 파싱 블록 제거
- [x] repo 형식 검증 코드를 람다 내부로 이동
- [x] 형식 오류 및 토큰 오류 시 `CommandExitedException(1)` throw로 대체
- [x] 오류 발생 시 도움말 안내 메시지 출력

### 🧪 테스트 방법
잘못된 형식 → 에러 + 도움말 안내 출력 확인
dotnet run -- invalidrepo
토큰 없이 실행 → 토큰 오류 + 도움말 안내 출력 확인
unset GITHUB_TOKEN
dotnet run -- oss2026hnu/reposcore-cs
정상 실행 확인
dotnet run -- oss2026hnu/reposcore-cs

### 💬 참고 사항
기존 `ShowHelp()`는 dotnet 프로세스를 재실행하여 help를 캡처하는 방식으로 오버헤드 및 어셈블리 경로 의존성 문제가 있었습니다. 이를 Cocona 설계에 맞는 `CommandExitedException`으로 대체했습니다.