### PR TITLE
GitHubService 쿼리 메서드 비동기 전환 및 PR/이슈·다중 저장소 병렬 실행

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using Cocona;
 using RepoScore.Data;
 using RepoScore.Services;
@@ -11,7 +12,7 @@ using System.Globalization;
 
 CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo("en-US");
 
-CoconaApp.Run((
+await CoconaApp.RunAsync(async (
 [Argument(Description = "대상 저장소 목록 (예: owner/repo1 owner/repo2)")] string[] repos,
 [Option('t', Description = "GitHub Token (미입력시 GITHUB_TOKEN 사용)")] string? token = null,
 [Option(Description = "최근 이슈 선점 현황 조회")] ClaimsMode? claims = null,
@@ -22,7 +23,7 @@ CoconaApp.Run((
 [Option(Description = "이슈 선점 키워드 (쉼표 구분, 미입력시 기본값 사용)")] string? keywords = null,
 [Option(Description = "캐시를 무시하고 전체 데이터를 다시 수집할지 여부")] bool noCache = false
 ) =>
-{   
+{
     var formatErrors = new List<string>();
     foreach (var repo in repos)
     {
@@ -53,140 +54,224 @@ CoconaApp.Run((
         ? keywords.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
         : null;
 
-    var totalUserIssues = new Dictionary<string, List<IssueRecord>>();
-    var totalUserPullRequests = new Dictionary<string, List<PRRecord>>();
+    // 저장소별 (issues, prs) 결과를 담을 딕셔너리 — 병렬 처리 후 합산에 사용
+    var repoResults = new System.Collections.Concurrent.ConcurrentDictionary<string, (Dictionary<string, List<IssueRecord>> UserIssues, Dictionary<string, List<PRRecord>> UserPrs)>();
 
-    foreach (var repo in repos)
+    // 다중 저장소를 병렬로 처리 (동시 실행 상한: 8)
+    using var semaphore = new System.Threading.SemaphoreSlim(8);
+
+    var repoTasks = repos.Select(async repo =>
     {
-        var parts = repo.Split('/');
-        string ownerName = parts[0];
-        string repoName = parts[1];
-
-        string repoOutput = repos.Length > 1
-            ? Path.Combine(output, $"{ownerName}_{repoName}")
-            : output;
-        if (!Directory.Exists(repoOutput)) Directory.CreateDirectory(repoOutput);
-        string cachePath = Path.Combine(repoOutput, "cache.json");
-        var cache = CacheManager.LoadCache(cachePath, repo, noCache);
-
-        var service = new GitHubService(ownerName, repoName, token, parsedKeywords);
-
+        await semaphore.WaitAsync();
         try
         {
-            // ── Claims 전용 모드 ──────────────────────────────────────────────────
-            if (claims != null)
-            {
-                AnsiConsole.MarkupLine($"[[[blue]{ownerName}/{repoName}[/]]] 최근 이슈 선점 현황을 조회합니다...\n");
+            var parts = repo.Split('/');
+            string ownerName = parts[0];
+            string repoName = parts[1];
 
-                DateTimeOffset? claimsSince = (!noCache && cache.LastClaimsAnalyzedAt != DateTimeOffset.MinValue)
-                    ? cache.LastClaimsAnalyzedAt
-                    : (DateTimeOffset?)null;
-
-                if (claimsSince.HasValue)
-                    Console.Error.WriteLine($"Claims 캐시 존재: {claimsSince.Value.ToLocalTime():yyyy-MM-dd HH:mm} — 이후 변경분만 재조회합니다.");
-                else
-                    Console.Error.WriteLine("Claims 캐시 없음: 전체 데이터를 수집합니다.");
-
-                var cachedOpenIssues = cache.CachedOpenIssues.Count > 0 ? cache.CachedOpenIssues : null;
-                var cachedOpenPrs = cache.CachedOpenPrs.Count > 0 ? cache.CachedOpenPrs : null;
-
-                var (claimsData, updatedOpenIssues, updatedOpenPrs) = service.GetRecentClaimsData(
-                    cachedOpenIssues, cachedOpenPrs, claimsSince);
-
-                var report = ReportFormatter.BuildClaimsReport(claimsData, (ClaimsMode)claims);
-                Console.Write(report);
-
-                CacheManager.SaveClaimsCache(cachePath, cache, updatedOpenIssues, updatedOpenPrs);
-                Console.Error.WriteLine($"Claims 캐시 갱신 완료: {cachePath}");
-
-                continue;
-            }
-
-            AnsiConsole.MarkupLine($"[yellow]{repo}[/] 기여자 데이터 수집 및 분석 중...");
-
+            string repoOutput = repos.Length > 1
+                ? Path.Combine(output, $"{ownerName}_{repoName}")
+                : output;
             if (!Directory.Exists(repoOutput)) Directory.CreateDirectory(repoOutput);
+            string cachePath = Path.Combine(repoOutput, "cache.json");
+            var cache = CacheManager.LoadCache(cachePath, repo, noCache);
 
-            if (!CacheManager.HasSameKeywords(cache, parsedKeywords))
+            var service = new GitHubService(ownerName, repoName, token, parsedKeywords);
+
+            try
             {
-                Console.Error.WriteLine("키워드 옵션이 이전 실행과 달라 캐시를 무효화합니다.");
-
-                cache = new RepoCache
+                // ── Claims 전용 모드 ──────────────────────────────────────────────────
+                if (claims != null)
                 {
-                    Repository = repo,
-                    Keywords = parsedKeywords
-                };
-            }
+                    AnsiConsole.MarkupLine($"[[[blue]{ownerName}/{repoName}[/]]] 최근 이슈 선점 현황을 조회합니다...\n");
 
-            DateTimeOffset? since = cache.LastAnalyzedAt == DateTimeOffset.MinValue
-                ? null
-                : cache.LastAnalyzedAt;
+                    DateTimeOffset? claimsSince = (!noCache && cache.LastClaimsAnalyzedAt != DateTimeOffset.MinValue)
+                        ? cache.LastClaimsAnalyzedAt
+                        : (DateTimeOffset?)null;
 
-            if (since.HasValue)
-            {
-                Console.Error.WriteLine($"기존 캐시 존재: {since.Value.ToLocalTime():yyyy-MM-dd HH:mm}");
-            }
-            else
-            {
-                Console.Error.WriteLine("기존 캐시 없음: 전체 데이터를 수집합니다.");
-            }
+                    if (claimsSince.HasValue)
+                        Console.Error.WriteLine($"[{repo}] Claims 캐시 존재: {claimsSince.Value.ToLocalTime():yyyy-MM-dd HH:mm} — 이후 변경분만 재조회합니다.");
+                    else
+                        Console.Error.WriteLine($"[{repo}] Claims 캐시 없음: 전체 데이터를 수집합니다.");
 
-            var allNewPrs = service.GetPullRequests(since);
-            var allNewIssues = service.GetIssues(since); // 존재하지 않는 저장소면 여기서 예외 발생
+                    var cachedOpenIssues = cache.CachedOpenIssues.Count > 0 ? cache.CachedOpenIssues : null;
+                    var cachedOpenPrs = cache.CachedOpenPrs.Count > 0 ? cache.CachedOpenPrs : null;
 
-            List<string> contributors = allNewPrs.Select(p => p.AuthorLogin)
-                .Concat(allNewIssues.Select(i => i.AuthorLogin))
-                .Concat(cache.UserIssues.Keys)
-                .Concat(cache.UserPullRequests.Keys)
-                .Where(login => !string.IsNullOrEmpty(login))
-                .Distinct()
-                .ToList();
+                    var (claimsData, updatedOpenIssues, updatedOpenPrs) = await service.GetRecentClaimsDataAsync(
+                        cachedOpenIssues, cachedOpenPrs, claimsSince);
 
-            if (contributors.Count == 0) { Console.Error.WriteLine("조회된 기여자가 없습니다."); continue; }
+                    var report = ReportFormatter.BuildClaimsReport(claimsData, (ClaimsMode)claims);
+                    Console.Write(report);
 
-            var reportData = new List<(string Id, int docIssues, int featBugIssues, int typoPrs, int docPrs, int featBugPrs, int Score)>();
+                    CacheManager.SaveClaimsCache(cachePath, cache, updatedOpenIssues, updatedOpenPrs);
+                    Console.Error.WriteLine($"[{repo}] Claims 캐시 갱신 완료: {cachePath}");
 
-            foreach (var user in contributors)
-            {
-                var newIssues = allNewIssues.Where(i => i.AuthorLogin == user).ToList();
-                var newPrs = allNewPrs.Where(p => p.AuthorLogin == user).ToList();
-
-                if (!cache.UserIssues.ContainsKey(user)) cache.UserIssues[user] = new List<IssueRecord>();
-                if (!cache.UserPullRequests.ContainsKey(user)) cache.UserPullRequests[user] = new List<PRRecord>();
-
-                foreach (var ni in newIssues)
-                {
-                    int index = cache.UserIssues[user].FindIndex(c => c.Number == ni.Number);
-                    if (index >= 0) cache.UserIssues[user][index] = ni;
-                    else cache.UserIssues[user].Add(ni);
+                    return;
                 }
 
-                foreach (var npr in newPrs)
+                AnsiConsole.MarkupLine($"[yellow]{repo}[/] 기여자 데이터 수집 및 분석 중...");
+
+                if (!Directory.Exists(repoOutput)) Directory.CreateDirectory(repoOutput);
+
+                if (!CacheManager.HasSameKeywords(cache, parsedKeywords))
                 {
-                    int index = cache.UserPullRequests[user].FindIndex(p => p.Number == npr.Number);
-                    if (index >= 0) cache.UserPullRequests[user][index] = npr;
-                    else cache.UserPullRequests[user].Add(npr);
+                    Console.Error.WriteLine($"[{repo}] 키워드 옵션이 이전 실행과 달라 캐시를 무효화합니다.");
+
+                    cache = new RepoCache
+                    {
+                        Repository = repo,
+                        Keywords = parsedKeywords
+                    };
                 }
 
-                var userIssuesToCalc = cache.UserIssues[user];
-                var prsToCalc = cache.UserPullRequests[user];
+                DateTimeOffset? since = cache.LastAnalyzedAt == DateTimeOffset.MinValue
+                    ? null
+                    : cache.LastAnalyzedAt;
 
-                var featureBugPrs = prsToCalc.Where(p => p.Labels.Contains(GitHubIssuePrLabel.Bug) || p.Labels.Contains(GitHubIssuePrLabel.Enhancement)).ToList();
-                var docPrs = prsToCalc.Where(p => p.Labels.Contains(GitHubIssuePrLabel.Documentation)).ToList();
-                var typoPrs = prsToCalc.Where(p => p.Labels.Contains(GitHubIssuePrLabel.Typo)).ToList();
-                var featureBugIssues = userIssuesToCalc.Where(c => c.Labels.Contains(GitHubIssuePrLabel.Bug) || c.Labels.Contains(GitHubIssuePrLabel.Enhancement)).ToList();
-                var docIssues = userIssuesToCalc.Where(c => c.Labels.Contains(GitHubIssuePrLabel.Documentation)).ToList();
+                if (since.HasValue)
+                    Console.Error.WriteLine($"[{repo}] 기존 캐시 존재: {since.Value.ToLocalTime():yyyy-MM-dd HH:mm}");
+                else
+                    Console.Error.WriteLine($"[{repo}] 기존 캐시 없음: 전체 데이터를 수집합니다.");
 
-                int finalScore
-                    = ScoreCalculator.CalculateFinalScore(featureBugPrs.Count, docPrs.Count, typoPrs.Count, featureBugIssues.Count, docIssues.Count);
+                // PR과 이슈를 병렬로 조회
+                var prsTask = service.GetPullRequestsAsync(since);
+                var issuesTask = service.GetIssuesAsync(since);
+                await Task.WhenAll(prsTask, issuesTask);
+                var allNewPrs = prsTask.Result;
+                var allNewIssues = issuesTask.Result;
 
-                reportData.Add((user, docIssues.Count, featureBugIssues.Count, typoPrs.Count, docPrs.Count, featureBugPrs.Count, finalScore));
+                List<string> contributors = allNewPrs.Select(p => p.AuthorLogin)
+                    .Concat(allNewIssues.Select(i => i.AuthorLogin))
+                    .Concat(cache.UserIssues.Keys)
+                    .Concat(cache.UserPullRequests.Keys)
+                    .Where(login => !string.IsNullOrEmpty(login))
+                    .Distinct()
+                    .ToList();
+
+                if (contributors.Count == 0)
+                {
+                    Console.Error.WriteLine($"[{repo}] 조회된 기여자가 없습니다.");
+                    return;
+                }
+
+                var reportData = new List<(string Id, int docIssues, int featBugIssues, int typoPrs, int docPrs, int featBugPrs, int Score)>();
+
+                // 저장소별 집계용 (합산에 사용)
+                var repoUserIssues = new Dictionary<string, List<IssueRecord>>();
+                var repoUserPrs = new Dictionary<string, List<PRRecord>>();
+
+                foreach (var user in contributors)
+                {
+                    var newIssues = allNewIssues.Where(i => i.AuthorLogin == user).ToList();
+                    var newPrs = allNewPrs.Where(p => p.AuthorLogin == user).ToList();
+
+                    if (!cache.UserIssues.ContainsKey(user)) cache.UserIssues[user] = new List<IssueRecord>();
+                    if (!cache.UserPullRequests.ContainsKey(user)) cache.UserPullRequests[user] = new List<PRRecord>();
+
+                    foreach (var ni in newIssues)
+                    {
+                        int index = cache.UserIssues[user].FindIndex(c => c.Number == ni.Number);
+                        if (index >= 0) cache.UserIssues[user][index] = ni;
+                        else cache.UserIssues[user].Add(ni);
+                    }
+
+                    foreach (var npr in newPrs)
+                    {
+                        int index = cache.UserPullRequests[user].FindIndex(p => p.Number == npr.Number);
+                        if (index >= 0) cache.UserPullRequests[user][index] = npr;
+                        else cache.UserPullRequests[user].Add(npr);
+                    }
+
+                    var userIssuesToCalc = cache.UserIssues[user];
+                    var prsToCalc = cache.UserPullRequests[user];
+
+                    var featureBugPrs = prsToCalc.Where(p => p.Labels.Contains(GitHubIssuePrLabel.Bug) || p.Labels.Contains(GitHubIssuePrLabel.Enhancement)).ToList();
+                    var docPrs = prsToCalc.Where(p => p.Labels.Contains(GitHubIssuePrLabel.Documentation)).ToList();
+                    var typoPrs = prsToCalc.Where(p => p.Labels.Contains(GitHubIssuePrLabel.Typo)).ToList();
+                    var featureBugIssues = userIssuesToCalc.Where(c => c.Labels.Contains(GitHubIssuePrLabel.Bug) || c.Labels.Contains(GitHubIssuePrLabel.Enhancement)).ToList();
+                    var docIssues = userIssuesToCalc.Where(c => c.Labels.Contains(GitHubIssuePrLabel.Documentation)).ToList();
+
+                    int finalScore = ScoreCalculator.CalculateFinalScore(featureBugPrs.Count, docPrs.Count, typoPrs.Count, featureBugIssues.Count, docIssues.Count);
+
+                    reportData.Add((user, docIssues.Count, featureBugIssues.Count, typoPrs.Count, docPrs.Count, featureBugPrs.Count, finalScore));
+
+                    if (repos.Length > 1)
+                    {
+                        repoUserIssues[user] = cache.UserIssues[user];
+                        repoUserPrs[user] = cache.UserPullRequests[user];
+                    }
+                }
+
+                CacheManager.SaveCache(cachePath, cache, parsedKeywords);
+                Console.Error.WriteLine($"[{repo}] 캐시 갱신 및 저장 완료: {cachePath}");
+
+                reportData = ReportSorter.SortReportData(reportData, sortBy, sortOrder);
+
+                var csv = new StringBuilder();
+                csv.AppendLine("아이디, 문서이슈, 버그/기능이슈, 오타PR, 문서PR, 버그/기능PR, 총점");
+                foreach (var r in reportData) csv.AppendLine($"{r.Id}, {r.docIssues}, {r.featBugIssues}, {r.typoPrs}, {r.docPrs}, {r.featBugPrs}, {r.Score}");
+
+                string csvPath = Path.Combine(repoOutput, "results.csv");
+                File.WriteAllText(csvPath, csv.ToString(), Encoding.UTF8);
+                Console.Error.WriteLine($"[{repo}] 기본 데이터(CSV) 저장 완료: {csvPath}");
+
+                if (format == OutputFormat.Txt)
+                {
+                    string txtPath = Path.Combine(repoOutput, "results.txt");
+                    string txtContent = ReportFormatter.BuildTextReport(repo, reportData);
+                    File.WriteAllText(txtPath, txtContent, Encoding.UTF8);
+                    Console.Error.WriteLine($"[{repo}] 가독성 리포트(TXT) 추가 저장 완료: {txtPath}");
+                }
+
+                if (format == OutputFormat.Html)
+                {
+                    string htmlPath = Path.Combine(repoOutput, "results.html");
+                    string htmlContent = ReportFormatter.BuildHtmlReport(repo, reportData);
+                    File.WriteAllText(htmlPath, htmlContent, Encoding.UTF8);
+                    Console.Error.WriteLine($"[{repo}] HTML 리포트 추가 저장 완료: {htmlPath}");
+                }
 
                 if (repos.Length > 1)
                 {
-                    if (!totalUserIssues.ContainsKey(user)) totalUserIssues[user] = new List<IssueRecord>();
-                    if (!totalUserPullRequests.ContainsKey(user)) totalUserPullRequests[user] = new List<PRRecord>();
+                    repoResults[repo] = (repoUserIssues, repoUserPrs);
+                }
+            }
+            catch (Exception ex)
+            {
+                if (ex.Message.Contains("Could not resolve to a Repository") ||
+                    (ex.InnerException?.Message.Contains("Could not resolve to a Repository") == true))
+                {
+                    Console.Error.WriteLine($"오류: '{repo}' 저장소가 존재하지 않거나 접근할 수 없습니다.");
+                    Environment.Exit(1);
+                    return;
+                }
+                AnsiConsole.WriteException(ex);
+            }
+        }
+        finally
+        {
+            semaphore.Release();
+        }
+    }).ToList();
 
-                    foreach (var issue in cache.UserIssues[user])
+    await Task.WhenAll(repoTasks);
+
+    if (repos.Length > 1 && repoResults.Count > 0)
+    {
+        try
+        {
+            AnsiConsole.MarkupLine($"\n[green]전체 저장소 합산 리포트 생성 중...[/]");
+
+            // 저장소별 결과를 순회하며 URL 기반 중복 제거 후 합산
+            var totalUserIssues = new Dictionary<string, List<IssueRecord>>();
+            var totalUserPullRequests = new Dictionary<string, List<PRRecord>>();
+
+            foreach (var (_, (userIssues, userPrs)) in repoResults)
+            {
+                foreach (var (user, issues) in userIssues)
+                {
+                    if (!totalUserIssues.ContainsKey(user)) totalUserIssues[user] = new List<IssueRecord>();
+                    foreach (var issue in issues)
                     {
                         bool isDuplicate = string.IsNullOrEmpty(issue.Url)
                             ? totalUserIssues[user].Any(i => string.IsNullOrEmpty(i.Url) && i.Number == issue.Number)
@@ -194,7 +279,12 @@ CoconaApp.Run((
                         if (!isDuplicate)
                             totalUserIssues[user].Add(issue);
                     }
-                    foreach (var pr in cache.UserPullRequests[user])
+                }
+
+                foreach (var (user, prs) in userPrs)
+                {
+                    if (!totalUserPullRequests.ContainsKey(user)) totalUserPullRequests[user] = new List<PRRecord>();
+                    foreach (var pr in prs)
                     {
                         bool isDuplicate = string.IsNullOrEmpty(pr.Url)
                             ? totalUserPullRequests[user].Any(p => string.IsNullOrEmpty(p.Url) && p.Number == pr.Number)
@@ -204,55 +294,6 @@ CoconaApp.Run((
                     }
                 }
             }
-
-            CacheManager.SaveCache(cachePath, cache, parsedKeywords);
-            Console.Error.WriteLine($"캐시 갱신 및 저장 완료: {cachePath}");
-
-            reportData = ReportSorter.SortReportData(reportData, sortBy, sortOrder);
-
-            var csv = new StringBuilder();
-            csv.AppendLine("아이디, 문서이슈, 버그/기능이슈, 오타PR, 문서PR, 버그/기능PR, 총점");
-            foreach (var r in reportData) csv.AppendLine($"{r.Id}, {r.docIssues}, {r.featBugIssues}, {r.typoPrs}, {r.docPrs}, {r.featBugPrs}, {r.Score}");
-
-            string csvPath = Path.Combine(repoOutput, "results.csv");
-            File.WriteAllText(csvPath, csv.ToString(), Encoding.UTF8);
-            Console.Error.WriteLine($"기본 데이터(CSV) 저장 완료: {csvPath}");
-
-            if (format == OutputFormat.Txt)
-            {
-                string txtPath = Path.Combine(repoOutput, "results.txt");
-                string txtContent = ReportFormatter.BuildTextReport(repo, reportData);
-                File.WriteAllText(txtPath, txtContent, Encoding.UTF8);
-                Console.Error.WriteLine($"가독성 리포트(TXT) 추가 저장 완료: {txtPath}");
-            }
-
-            if (format == OutputFormat.Html)
-            {
-                string htmlPath = Path.Combine(repoOutput, "results.html");
-                string htmlContent = ReportFormatter.BuildHtmlReport(repo, reportData);
-                File.WriteAllText(htmlPath, htmlContent, Encoding.UTF8);
-                Console.Error.WriteLine($"HTML 리포트 추가 저장 완료: {htmlPath}");
-            }
-        }
-        catch (Exception ex)
-        {
-            // 저장소가 존재하지 않는 경우 예외 메시지로 판단
-            if (ex.Message.Contains("Could not resolve to a Repository") ||
-                (ex.InnerException?.Message.Contains("Could not resolve to a Repository") == true))
-            {
-                Console.Error.WriteLine($"오류: '{repo}' 저장소가 존재하지 않거나 접근할 수 없습니다.");
-                Environment.Exit(1);
-                return;
-            }
-            AnsiConsole.WriteException(ex);
-        }
-    }
-
-    if (repos.Length > 1 && (totalUserIssues.Count > 0 || totalUserPullRequests.Count > 0))
-    {
-        try
-        {
-            AnsiConsole.MarkupLine($"\n[green]전체 저장소 합산 리포트 생성 중...[/]");
 
             var totalReportData = new List<(string Id, int docIssues, int featBugIssues, int typoPrs, int docPrs, int featBugPrs, int Score)>();
 

--- a/Services/GitHubService.cs
+++ b/Services/GitHubService.cs
@@ -96,9 +96,9 @@ namespace RepoScore.Services
                 new Octokit.GraphQL.ProductHeaderValue("reposcore-cs"), token);
         }
 
-        // 저장소의 머지된 전체 PR 목록을 GraphQL로 조회.
+        // 저장소의 머지된 전체 PR 목록을 GraphQL로 비동기 조회.
         // since가 지정된 경우 해당 시각 이후 업데이트된 PR만 가져옴.
-        public List<PRRecord> GetPullRequests(DateTimeOffset? since = null)
+        public async System.Threading.Tasks.Task<List<PRRecord>> GetPullRequestsAsync(DateTimeOffset? since = null)
         {
             string searchString = $"repo:{_owner}/{_repo} is:pr is:merged";
             if (since.HasValue)
@@ -130,7 +130,7 @@ namespace RepoScore.Services
                         }).ToList()
                     });
 
-                var result = _graphQLConnection.Run(query).Result;
+                var result = await _graphQLConnection.Run(query);
 
                 foreach (var pr in result.Items)
                 {
@@ -153,11 +153,11 @@ namespace RepoScore.Services
             return prRecords;
         }
 
-        // 저장소의 전체 이슈 목록을 GraphQL로 조회.
+        // 저장소의 전체 이슈 목록을 GraphQL로 비동기 조회.
         // "not planned", "duplicate" 사유로 닫힌 이슈는 제외.
         // since가 지정된 경우 해당 시각 이후 업데이트된 이슈만 가져옴.
         // repository 필드를 search와 함께 요청하여 존재하지 않는 저장소면 예외 발생.
-        public List<IssueRecord> GetIssues(DateTimeOffset? since = null)
+        public async System.Threading.Tasks.Task<List<IssueRecord>> GetIssuesAsync(DateTimeOffset? since = null)
         {
             const string rawGraphQl = @"
             query($owner: String!, $repoName: String!, $searchQuery: String!, $after: String) {
@@ -213,7 +213,7 @@ namespace RepoScore.Services
                     }
                 });
 
-                var rawResponse = _graphQLConnection.Run(requestPayload).Result;
+                var rawResponse = await _graphQLConnection.Run(requestPayload);
                 using var document = JsonDocument.Parse(rawResponse);
 
                 // errors 필드가 있으면 저장소 없음 등의 오류 → 예외로 전달
@@ -282,9 +282,9 @@ namespace RepoScore.Services
             return issueRecords;
         }
 
-        // 저장소의 열린 이슈를 대상으로 최근 48시간 내 선점 현황을 조회.
-        public (ClaimsData claimsData, List<IssueRecord> updatedOpenIssues, List<PRRecord> updatedOpenPrs)
-            GetRecentClaimsData(
+        // 저장소의 열린 이슈를 대상으로 최근 48시간 내 선점 현황을 비동기 조회.
+        public async System.Threading.Tasks.Task<(ClaimsData claimsData, List<IssueRecord> updatedOpenIssues, List<PRRecord> updatedOpenPrs)>
+            GetRecentClaimsDataAsync(
                 List<IssueRecord>? cachedOpenIssues = null,
                 List<PRRecord>? cachedOpenPrs = null,
                 DateTimeOffset? since = null)
@@ -292,7 +292,7 @@ namespace RepoScore.Services
             var now = DateTimeOffset.UtcNow;
             bool isFullRefresh = since == null || (now - since.Value).TotalHours > 48;
 
-            var freshOpenPrs = GetOpenPullRequestsWithLinkedIssues(isFullRefresh ? null : since);
+            var freshOpenPrs = await GetOpenPullRequestsWithLinkedIssuesAsync(isFullRefresh ? null : since);
 
             List<PRRecord> updatedOpenPrs;
             if (isFullRefresh || cachedOpenPrs == null)
@@ -318,7 +318,7 @@ namespace RepoScore.Services
                 }
             }
 
-            var (freshIssues, closedIssueNumbers) = FetchOpenIssuesWithClaimComments(
+            var (freshIssues, closedIssueNumbers) = await FetchOpenIssuesWithClaimCommentsAsync(
                 isFullRefresh ? null : since);
 
             List<IssueRecord> updatedOpenIssues;
@@ -379,9 +379,9 @@ namespace RepoScore.Services
             return (claimsData, updatedOpenIssues, updatedOpenPrs);
         }
 
-        // 열린 이슈와 선점 댓글을 함께 조회.
-        private (List<IssueRecord> openIssues, HashSet<int> closedIssueNumbers)
-            FetchOpenIssuesWithClaimComments(DateTimeOffset? since = null)
+        // 열린 이슈와 선점 댓글을 함께 비동기 조회.
+        private async System.Threading.Tasks.Task<(List<IssueRecord> openIssues, HashSet<int> closedIssueNumbers)>
+            FetchOpenIssuesWithClaimCommentsAsync(DateTimeOffset? since = null)
         {
             var openIssues = new List<IssueRecord>();
             var closedIssueNumbers = new HashSet<int>();
@@ -418,7 +418,7 @@ namespace RepoScore.Services
                         }
                     });
 
-                    var rawResponse = _graphQLConnection.Run(payload).Result;
+                    var rawResponse = await _graphQLConnection.Run(payload);
                     using var doc = JsonDocument.Parse(rawResponse);
 
                     if (!doc.RootElement.TryGetProperty("data", out var dataEl) ||
@@ -468,7 +468,7 @@ namespace RepoScore.Services
                         }).ToList()
                     });
 
-                var result = _graphQLConnection.Run(query).Result;
+                var result = await _graphQLConnection.Run(query);
 
                 foreach (var issue in result.Items)
                 {
@@ -521,8 +521,8 @@ namespace RepoScore.Services
             return (openIssues, closedIssueNumbers);
         }
 
-        // since 이후 업데이트된 열린 PR과 본문에서 파싱한 연결 이슈 번호 목록을 반환.
-        public List<PRWithLinkedIssues> GetOpenPullRequestsWithLinkedIssues(DateTimeOffset? since = null)
+        // since 이후 업데이트된 열린 PR과 본문에서 파싱한 연결 이슈 번호 목록을 비동기 반환.
+        public async System.Threading.Tasks.Task<List<PRWithLinkedIssues>> GetOpenPullRequestsWithLinkedIssuesAsync(DateTimeOffset? since = null)
         {
             var prsWithIssues = new List<PRWithLinkedIssues>();
             string? cursor = null;
@@ -551,7 +551,7 @@ namespace RepoScore.Services
                         }).ToList()
                     });
 
-                var result = _graphQLConnection.Run(query).Result;
+                var result = await _graphQLConnection.Run(query);
 
                 foreach (var pr in result.Items)
                 {


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #437 

### 변경사항
- [x] `GitHubService.cs` — `GetPullRequests`, `GetIssues`, `GetRecentClaimsData` 등 쿼리 메서드를 `async Task<T>` 시그니처로 변환 (`GetPullRequestsAsync`, `GetIssuesAsync`, `GetRecentClaimsDataAsync`)
- [x] `GitHubService.cs` — 내부 `.Result` 블로킹 호출 5개를 모두 `await`으로 교체하여 sync-over-async 패턴 제거
- [x] `Program.cs` — 한 저장소 내 PR/이슈 조회를 `Task.WhenAll`로 병렬 실행
- [x] `Program.cs` — 다중 저장소 처리를 `foreach` 직렬에서 `Task.WhenAll` 병렬로 전환
- [x] `Program.cs` — `SemaphoreSlim(8)`으로 동시 실행 상한 적용 (레이트 리밋 대비)
- [x] `Program.cs` — 병렬 환경에서의 공유 가변 상태 경쟁 방지를 위해 저장소별 결과를 `ConcurrentDictionary`로 수집 후 직렬 합산으로 리팩터링
- [x] `Program.cs` — `CoconaApp.Run` → `CoconaApp.RunAsync` (async 람다) 전환
- [x] 병렬 실행 시 로그 식별성 확보를 위해 모든 출력에 `[owner/repo]` prefix 일관 적용

### 🧪 테스트 방법
```bash
# 단일 저장소 (PR/이슈 병렬 조회 확인)
dotnet run -- oss2026hnu/reposcore-cs

# 다중 저장소 (저장소 간 병렬 처리 및 합산 리포트 확인)
dotnet run -- oss2026hnu/reposcore-cs oss2026hnu/reposcore-ts
```
