### PR TITLE
docs: 문서 갱신 명령어를 make 명령으로 통일

### DIFF
--- a/README-template.md.j2
+++ b/README-template.md.j2
@@ -48,11 +48,7 @@ dotnet run -- --help
 Synopsis 섹션은 CLI 도움말을 자동으로 반영합니다. 프로그램 옵션 또는 실행 방식이 변경되면 다음 명령어로 업데이트하세요:
 
 ```bash
-# 개별 업데이트
-python tools/update-synopsis.py
-python tools/j2render.py README-template.md.j2 vars/synopsis.json -o README.md
-
-# 또는 Makefile로
+# synopsis만 업데이트
 make synopsis
 
 # docs와 함께 업데이트

--- a/README.md
+++ b/README.md
@@ -65,11 +65,7 @@ Options:
 Synopsis 섹션은 CLI 도움말을 자동으로 반영합니다. 프로그램 옵션 또는 실행 방식이 변경되면 다음 명령어로 업데이트하세요:
 
 ```bash
-# 개별 업데이트
-python tools/update-synopsis.py
-python tools/j2render.py README-template.md.j2 vars/synopsis.json -o README.md
-
-# 또는 Makefile로
+# synopsis만 업데이트
 make synopsis
 
 # docs와 함께 업데이트

--- a/docs/README-template.md.j2
+++ b/docs/README-template.md.j2
@@ -1,15 +1,11 @@
 # 프로젝트 운영 지침 및 개발 가이드
-
 ### 문서 목록
-
 <!-- DOC_LIST_START -->
 {% for doc in docs %}
 - [{{ doc.filename }}](./{{ doc.filename }}): {{ doc.title }}
 {%- endfor %}
 <!-- DOC_LIST_END -->
-
 ---
-
 > ⚠️**아래 상황이 발생하면 반드시 스크립트를 통해 목록을 자동 갱신해줘야 합니다.**
 >
 > - docs/README.md 파일을 업데이트하기 위해 docs/README-template.md.j2 파일을 수정한 경우
@@ -24,67 +20,39 @@
 > ```
 >
 > ```bash
-> python tools/update-doclist.py
-> python tools/j2render.py docs/README-template.md.j2 vars/doclist.json -o docs/README.md
+> make docs
 > ```
->
-> 스크립트 위치: `tools/update-doclist.py`, `tools/j2render.py`
 >
 > ⚠️ **수작업으로 문서 목록 갱신하지 마세요.**
 > ⚠️ **docs/README.md 파일을 직접 수정하지 마세요.**
-
 ---
-
 ## docs/README.md 파일 수정 가이드
-
 > ⚠️ `docs/README.md`를 직접 수정하지 마세요.
-
-`docs/README.md`를 수정하려면 먼저 `docs/README-template.md.j2`를 업데이트한 후, 루트 디렉터리에서 아래 명령어를 실행하여 `docs/README.md`를 자동으로 갱신하세요.
-
+`docs/README.md`를 수정하려면 먼저 `docs/README-template.md.j2`를 업데이트한 후, 루트 디렉터리에서 `make docs`를 실행하여 `docs/README.md`를 자동으로 갱신하세요.
 ### 수정 방법
-
 1. `docs/README-template.md.j2`를 업데이트합니다.
-2. 루트 디렉터리에서 아래 명령어를 실행합니다.
-
-   ```bash
-   python tools/update-doclist.py
-   python tools/j2render.py docs/README-template.md.j2 vars/doclist.json -o docs/README.md
-   ```
-
+2. 루트 디렉터리에서 `make docs`를 실행합니다.
 3. 커밋하기 전에 `docs/README.md`가 자동으로 갱신되었는지 확인합니다.
-
 ## 문서 파일 생성 규칙
-
 프로젝트 내 문서 파일의 일관성을 유지하기 위해 다음과 같은 파일 이름 생성 규칙을 따릅니다.
-
 ### 기본 규칙
-
 - 모든 파일 이름은 소문자(lowercase)를 사용합니다.
 - 단어 구분은 공백 대신 하이픈(-)을 사용합니다.
 - 파일 확장자는 `.md`를 사용합니다.
-
 ### 예시
-
 - `setup-guide.md`
 - `api-reference.md`
 - `contributing-guide.md`
 - `error-handling.md`
-
 ### 추가 규칙
-
 - 파일 이름은 간결하고 의미를 명확하게 전달해야 합니다.
 - 불필요한 특수문자는 사용하지 않습니다.
 - 동일한 의미의 단어는 통일하여 사용합니다 (예: guide, doc 등)
-
 ---
-
 ## 주의사항
-
 문서 관련 이슈 작성 시 반드시 아래를 명시해주세요:
-
 - 대상 문서의 정확한 경로 (예: docs/cli-lib-guide.md)
 - 수정 또는 추가할 내용
-
 새 md 문서 작성 시:
-
 - #하나로 시작하는 문서의 최상위 제목을 반드시 작성(예: # 문서 제목)
+   

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,5 @@
 # 프로젝트 운영 지침 및 개발 가이드
-
 ### 문서 목록
-
 <!-- DOC_LIST_START -->
 
 - [cli-options-guide.md](./cli-options-guide.md): CLI 옵션 사용 가이드
@@ -16,9 +14,7 @@
 - [score-guide.md](./score-guide.md): 오픈소스 기여 점수 산정 가이드
 - [vscode-extensions.md](./vscode-extensions.md): C# 개발을 위한 VSCode 확장 가이드
 <!-- DOC_LIST_END -->
-
 ---
-
 > ⚠️**아래 상황이 발생하면 반드시 스크립트를 통해 목록을 자동 갱신해줘야 합니다.**
 >
 > - docs/README.md 파일을 업데이트하기 위해 docs/README-template.md.j2 파일을 수정한 경우
@@ -33,67 +29,39 @@
 > ```
 >
 > ```bash
-> python tools/update-doclist.py
-> python tools/j2render.py docs/README-template.md.j2 vars/doclist.json -o docs/README.md
+> make docs
 > ```
->
-> 스크립트 위치: `tools/update-doclist.py`, `tools/j2render.py`
 >
 > ⚠️ **수작업으로 문서 목록 갱신하지 마세요.**
 > ⚠️ **docs/README.md 파일을 직접 수정하지 마세요.**
-
 ---
-
 ## docs/README.md 파일 수정 가이드
-
 > ⚠️ `docs/README.md`를 직접 수정하지 마세요.
-
-`docs/README.md`를 수정하려면 먼저 `docs/README-template.md.j2`를 업데이트한 후, 루트 디렉터리에서 아래 명령어를 실행하여 `docs/README.md`를 자동으로 갱신하세요.
-
+`docs/README.md`를 수정하려면 먼저 `docs/README-template.md.j2`를 업데이트한 후, 루트 디렉터리에서 `make docs`를 실행하여 `docs/README.md`를 자동으로 갱신하세요.
 ### 수정 방법
-
 1. `docs/README-template.md.j2`를 업데이트합니다.
-2. 루트 디렉터리에서 아래 명령어를 실행합니다.
-
-   ```bash
-   python tools/update-doclist.py
-   python tools/j2render.py docs/README-template.md.j2 vars/doclist.json -o docs/README.md
-   ```
-
+2. 루트 디렉터리에서 `make docs`를 실행합니다.
 3. 커밋하기 전에 `docs/README.md`가 자동으로 갱신되었는지 확인합니다.
-
 ## 문서 파일 생성 규칙
-
 프로젝트 내 문서 파일의 일관성을 유지하기 위해 다음과 같은 파일 이름 생성 규칙을 따릅니다.
-
 ### 기본 규칙
-
 - 모든 파일 이름은 소문자(lowercase)를 사용합니다.
 - 단어 구분은 공백 대신 하이픈(-)을 사용합니다.
 - 파일 확장자는 `.md`를 사용합니다.
-
 ### 예시
-
 - `setup-guide.md`
 - `api-reference.md`
 - `contributing-guide.md`
 - `error-handling.md`
-
 ### 추가 규칙
-
 - 파일 이름은 간결하고 의미를 명확하게 전달해야 합니다.
 - 불필요한 특수문자는 사용하지 않습니다.
 - 동일한 의미의 단어는 통일하여 사용합니다 (예: guide, doc 등)
-
 ---
-
 ## 주의사항
-
 문서 관련 이슈 작성 시 반드시 아래를 명시해주세요:
-
 - 대상 문서의 정확한 경로 (예: docs/cli-lib-guide.md)
 - 수정 또는 추가할 내용
-
 새 md 문서 작성 시:
-
 - #하나로 시작하는 문서의 최상위 제목을 반드시 작성(예: # 문서 제목)
+   


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #454

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- [ ] `README-template.md.j2` (루트): Synopsis 업데이트 섹션의 `python tools/...` 직접 실행 안내 제거 → `make synopsis`, `make`로 통일
- [ ] `docs/README-template.md.j2`: 문서 갱신 안내의 `python tools/...` 직접 실행 안내 제거 → `make docs`로 통일, 스크립트 위치 안내 줄 삭제
- [ ] `docs/README.md`: `make docs` 실행으로 자동 갱신
- [ ] `README.md`: `make` 실행으로 자동 갱신

### 💬 참고 사항 (선택 사항)
<!-- 리뷰 시 참고해야 할 내용이나 전달하고 싶은 사항이 있다면 작성해주세요 -->
- 기존 `python tools/update-doclist.py`, `python tools/j2render.py ...` 안내를 제거하고 `make docs` 단일 명령으로 통일했습니다.
- 사용자가 내부 스크립트 이름을 직접 알 필요 없도록 인터페이스를 단순화했습니다.
- Codespaces 실행 안내 등 기존 구조는 그대로 유지했습니다.