### PR TITLE
Remove filtering of pull requests by UpdatedAt

### DIFF
--- a/Services/GitHubService.cs
+++ b/Services/GitHubService.cs
@@ -696,8 +696,6 @@ namespace RepoScore.Services
 
                 foreach (var pr in result.Items)
                 {
-                    if (since.HasValue && pr.UpdatedAt < since.Value)
-                        continue;
 
                     var linkedIssueNumbers = new HashSet<int>();
 


### PR DESCRIPTION
Remove outdated pull request filtering based on UpdatedAt.

### ISSUE_ID
Closes oss2026hnu/reposcore-ts#164

### 변경사항
- [ ] 최근 48시간 데이터 갱신 시 `GetOpenPullRequestsWithLinkedIssuesAsync` 내에서 `since` 기준보다 오래된 오픈 PR을 `continue;`로 필터링하던 로직 제거
- [ ] 오래된 오픈 PR이라도 내부에 연동된 `#이슈번호` 파싱 과정에서 누락되지 않도록 수정하여 기여도 점수 합산이 누락되는 버그 해결

### 🧪 테스트 방법 (선택 사항)

### 💬 참고 사항 (선택 사항)
