### PR TITLE
[FEAT] Cocona ValueName 적용으로 --help 옵션 값 이름 직관화 (#475)

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -14,13 +14,13 @@ CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo("en-US");
 
 await CoconaApp.RunAsync(async (
 [Argument(Description = "대상 저장소 목록 (예: owner/repo1 owner/repo2)")] string[] repos,
-[Option('t', Description = "GitHub Token (미입력시 GITHUB_TOKEN 사용)")] string? token = null,
+[Option('t', Description = "GitHub Token (미입력시 GITHUB_TOKEN 사용)", ValueName = "TOKEN")] string? token = null,
 [Option(Description = "최근 이슈 선점 현황 조회")] ClaimsMode? claims = null,
 [Option('f', Description = "출력 형식")] OutputFormat format = OutputFormat.Csv,
-[Option('o', Description = "출력 디렉토리 경로")] string output = "./results",
+[Option('o', Description = "출력 디렉토리 경로", ValueName = "DIR")] string output = "./results",
 [Option(Description = "정렬 기준")] SortBy sortBy = SortBy.Score,
 [Option(Description = "정렬 방법")] SortOrder sortOrder = SortOrder.Desc,
-[Option(Description = "이슈 선점 키워드 (쉼표 구분, 미입력시 기본값 사용)")] string? keywords = null,
+[Option(Description = "이슈 선점 키워드 (쉼표 구분, 미입력시 기본값 사용)", ValueName = "KEYWORDS")] string? keywords = null,
 [Option(Description = "캐시를 무시하고 전체 데이터를 다시 수집할지 여부")] bool noCache = false
 ) =>
 {

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ dotnet run -- --help
 ## Synopsis
 
 ```text
-Usage: reposcore-cs [--token <String>] [--claims <ClaimsMode>] [--format <OutputFormat>] [--output <String>] [--sort-by <SortBy>] [--sort-order <SortOrder>] [--keywords <String>] [--no-cache] [--help] [--version] repos0 ... reposN
+Usage: reposcore-cs [--token <TOKEN>] [--claims <ClaimsMode>] [--format <OutputFormat>] [--output <DIR>] [--sort-by <SortBy>] [--sort-order <SortOrder>] [--keywords <KEYWORDS>] [--no-cache] [--help] [--version] repos0 ... reposN
 
 reposcore-cs
 
@@ -48,13 +48,13 @@ Arguments:
   0: repos    대상 저장소 목록 (예: owner/repo1 owner/repo2) (Required)
 
 Options:
-  -t, --token <String>           GitHub Token (미입력시 GITHUB_TOKEN 사용)
+  -t, --token <TOKEN>            GitHub Token (미입력시 GITHUB_TOKEN 사용)
   --claims <ClaimsMode>          최근 이슈 선점 현황 조회 (Allowed values: Issue, User)
   -f, --format <OutputFormat>    출력 형식 (Default: Csv) (Allowed values: Csv, Txt, Html)
-  -o, --output <String>          출력 디렉토리 경로 (Default: ./results)
+  -o, --output <DIR>             출력 디렉토리 경로 (Default: ./results)
   --sort-by <SortBy>             정렬 기준 (Default: Score) (Allowed values: Score, Id)
   --sort-order <SortOrder>       정렬 방법 (Default: Desc) (Allowed values: Asc, Desc)
-  --keywords <String>            이슈 선점 키워드 (쉼표 구분, 미입력시 기본값 사용)
+  --keywords <KEYWORDS>          이슈 선점 키워드 (쉼표 구분, 미입력시 기본값 사용)
   --no-cache                     캐시를 무시하고 전체 데이터를 다시 수집할지 여부
   -h, --help                     Show help message
   --version                      Show version


### PR DESCRIPTION
### ISSUE_ID
Closes #475

### 변경사항
- [x] Cocona `[Option]`의 `ValueName` 속성을 활용해 `--help` 도움말의 값 이름을 직관화
  - `--token` : `<String>` → `<TOKEN>`
  - `--output` : `<String>` → `<DIR>`
  - `--keywords` : `<String>` → `<KEYWORDS>`
- [x] 옵션 표기 변경에 따라 `make`로 `README.md` synopsis 재생성
- [x] enum 옵션(`--format`, `--sort-by`, `--sort-order`, `--claims`)은 타입명 + `Allowed values`로 이미 의미가 드러나 변경하지 않음

### 🧪 테스트 방법 (선택 사항)
1. 빌드 및 테스트
   ```bash
   dotnet build      # 경고 0, 오류 0
   dotnet test RepoScore.Tests/RepoScore.Tests.csproj   # 43개 통과
   ```
2. 도움말 출력 확인
   ```bash
   dotnet run -- --help
   ```
   - `-t, --token <TOKEN>`, `-o, --output <DIR>`, `--keywords <KEYWORDS>` 로 표시되는지 확인
3. synopsis 동기화 확인
   ```bash
   make
   git diff --exit-code -- README.md   # 차이 없음(이미 갱신 커밋됨)
   ```

### 💬 참고 사항 (선택 사항)
- 옵션 시그니처(`Program.cs`)가 바뀌므로 `docs-synopsis-validation` 워크플로 대비 `README.md`를 함께 갱신해 커밋했습니다.
- `docs/README.md`(문서 목록)는 파일명·최상위 제목 변경이 없어 영향 없습니다.