### PR TITLE
fix: 남은 콘솔 진단 출력을 Serilog 로그로 교체

### DIFF
--- a/Data/CacheManager.cs
+++ b/Data/CacheManager.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using RepoScore.Services;
+using Serilog;
 
 namespace RepoScore.Data
 {
@@ -78,7 +79,7 @@ namespace RepoScore.Data
         {
             if (noCache)
             {
-                Console.Error.WriteLine("ℹ️  캐시를 무시하고 전체 데이터를 다시 수집합니다.");
+                Log.Information("캐시를 무시하고 전체 데이터를 다시 수집합니다.");
                 return new RepoCache { Repository = repoName };
             }
 
@@ -100,7 +101,7 @@ namespace RepoScore.Data
             }
             catch
             {
-                Console.Error.WriteLine("⚠️ 기존 캐시 파일이 손상되어 새로 수집을 시작합니다.");
+                Log.Warning("기존 캐시 파일이 손상되어 새로 수집을 시작합니다.");
                 return new RepoCache { Repository = repoName };
             }
         }

--- a/Program.cs
+++ b/Program.cs
@@ -16,13 +16,13 @@ CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo("en-US");
 
 await CoconaApp.RunAsync(async (
 [Argument(Description = "대상 저장소 목록 (예: owner/repo1 owner/repo2)")] string[] repos,
-[Option('t', Description = "GitHub Token (미입력시 GITHUB_TOKEN 사용)")] string? token = null,
+[Option('t', Description = "GitHub Token (미입력시 GITHUB_TOKEN 사용)", ValueName = "TOKEN")] string? token = null,
 [Option(Description = "최근 이슈 선점 현황 조회")] ClaimsMode? claims = null,
 [Option('f', Description = "출력 형식")] OutputFormat format = OutputFormat.Csv,
-[Option('o', Description = "출력 디렉토리 경로")] string output = "./results",
+[Option('o', Description = "출력 디렉토리 경로", ValueName = "DIR")] string output = "./results",
 [Option(Description = "정렬 기준")] SortBy sortBy = SortBy.Score,
 [Option(Description = "정렬 방법")] SortOrder sortOrder = SortOrder.Desc,
-[Option(Description = "이슈 선점 키워드 (쉼표 구분, 미입력시 기본값 사용)")] string? keywords = null,
+[Option(Description = "이슈 선점 키워드 (쉼표 구분, 미입력시 기본값 사용)", ValueName = "KEYWORDS")] string? keywords = null,
 [Option(Description = "캐시를 무시하고 전체 데이터를 다시 수집할지 여부")] bool noCache = false,
 [Option(Description = "로그 상세 수준 (0=기본, 1=진행 정보, 2=디버그, 3=상세 디버그)")] int verbose = 0
 ) =>

--- a/Program.cs
+++ b/Program.cs
@@ -16,13 +16,13 @@ CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo("en-US");
 
 await CoconaApp.RunAsync(async (
 [Argument(Description = "대상 저장소 목록 (예: owner/repo1 owner/repo2)")] string[] repos,
-[Option('t', Description = "GitHub Token (미입력시 GITHUB_TOKEN 사용)", ValueName = "TOKEN")] string? token = null,
+[Option('t', Description = "GitHub Token (미입력시 GITHUB_TOKEN 사용)")] string? token = null,
 [Option(Description = "최근 이슈 선점 현황 조회")] ClaimsMode? claims = null,
 [Option('f', Description = "출력 형식")] OutputFormat format = OutputFormat.Csv,
-[Option('o', Description = "출력 디렉토리 경로", ValueName = "DIR")] string output = "./results",
+[Option('o', Description = "출력 디렉토리 경로")] string output = "./results",
 [Option(Description = "정렬 기준")] SortBy sortBy = SortBy.Score,
 [Option(Description = "정렬 방법")] SortOrder sortOrder = SortOrder.Desc,
-[Option(Description = "이슈 선점 키워드 (쉼표 구분, 미입력시 기본값 사용)", ValueName = "KEYWORDS")] string? keywords = null,
+[Option(Description = "이슈 선점 키워드 (쉼표 구분, 미입력시 기본값 사용)")] string? keywords = null,
 [Option(Description = "캐시를 무시하고 전체 데이터를 다시 수집할지 여부")] bool noCache = false,
 [Option(Description = "로그 상세 수준 (0=기본, 1=진행 정보, 2=디버그, 3=상세 디버그)")] int verbose = 0
 ) =>
@@ -52,18 +52,16 @@ await CoconaApp.RunAsync(async (
     if (formatErrors.Count > 0)
     {
         foreach (var error in formatErrors)
-            Console.Error.WriteLine(error);
-        Console.Error.WriteLine();
-        Console.Error.WriteLine("도움말을 보려면 --help 옵션을 사용하세요.");
+            Log.Error("{Error}", error);
+        Log.Error("도움말을 보려면 --help 옵션을 사용하세요.");
         throw new CommandExitedException(1);
     }
 
     token ??= Environment.GetEnvironmentVariable("GITHUB_TOKEN");
     if (string.IsNullOrEmpty(token))
     {
-        Console.Error.WriteLine("오류: GitHub 토큰이 필요합니다.");
-        Console.Error.WriteLine();
-        Console.Error.WriteLine("도움말을 보려면 --help 옵션을 사용하세요.");
+        Log.Error("오류: GitHub 토큰이 필요합니다.");
+        Log.Error("도움말을 보려면 --help 옵션을 사용하세요.");
         throw new CommandExitedException(1);
     }
 
@@ -132,7 +130,7 @@ await CoconaApp.RunAsync(async (
 
                 if (!CacheManager.HasSameKeywords(cache, parsedKeywords))
                 {
-                    Console.Error.WriteLine($"[{repo}] 키워드 옵션이 이전 실행과 달라 캐시를 무효화합니다.");
+                    Log.Information("[{Repo}] 키워드 옵션이 이전 실행과 달라 캐시를 무효화합니다.", repo);
 
                     cache = new RepoCache
                     {
@@ -168,7 +166,7 @@ await CoconaApp.RunAsync(async (
 
                 if (contributors.Count == 0)
                 {
-                    Console.Error.WriteLine($"[{repo}] 조회된 기여자가 없습니다.");
+                    Log.Warning("[{Repo}] 조회된 기여자가 없습니다.", repo);
                     return;
                 }
 
@@ -238,7 +236,7 @@ await CoconaApp.RunAsync(async (
                     string txtPath = Path.Combine(repoOutput, "results.txt");
                     string txtContent = ReportFormatter.BuildTextReport(repo, reportData);
                     File.WriteAllText(txtPath, txtContent, Encoding.UTF8);
-                    Console.Error.WriteLine($"[{repo}] 가독성 리포트(TXT) 추가 저장 완료: {txtPath}");
+                    Log.Information("[{Repo}] 가독성 리포트(TXT) 추가 저장 완료: {TxtPath}", repo, txtPath);
                 }
 
                 if (format == OutputFormat.Html)
@@ -246,7 +244,7 @@ await CoconaApp.RunAsync(async (
                     string htmlPath = Path.Combine(repoOutput, "results.html");
                     string htmlContent = ReportFormatter.BuildHtmlReport(repo, reportData);
                     File.WriteAllText(htmlPath, htmlContent, Encoding.UTF8);
-                    Console.Error.WriteLine($"[{repo}] HTML 리포트 추가 저장 완료: {htmlPath}");
+                    Log.Information("[{Repo}] HTML 리포트 추가 저장 완료: {HtmlPath}", repo, htmlPath);
                 }
 
                 if (repos.Length > 1)
@@ -259,11 +257,11 @@ await CoconaApp.RunAsync(async (
                 if (ex.Message.Contains("Could not resolve to a Repository") ||
                     (ex.InnerException?.Message.Contains("Could not resolve to a Repository") == true))
                 {
-                    Console.Error.WriteLine($"오류: '{repo}' 저장소가 존재하지 않거나 접근할 수 없습니다.");
+                    Log.Error("오류: '{Repo}' 저장소가 존재하지 않거나 접근할 수 없습니다.", repo);
                     Environment.Exit(1);
                     return;
                 }
-                AnsiConsole.WriteException(ex);
+                Log.Error(ex, "처리 중 예외가 발생했습니다.");
             }
         }
         finally
@@ -344,7 +342,7 @@ await CoconaApp.RunAsync(async (
 
             string totalCsvPath = Path.Combine(totalOutput, "results.csv");
             File.WriteAllText(totalCsvPath, totalCsv.ToString(), Encoding.UTF8);
-            Console.Error.WriteLine($"전체 합산 데이터(CSV) 저장 완료: {totalCsvPath}");
+            Log.Information("전체 합산 데이터(CSV) 저장 완료: {TotalCsvPath}", totalCsvPath);
 
             if (format == OutputFormat.Txt)
             {
@@ -352,7 +350,7 @@ await CoconaApp.RunAsync(async (
                 string totalTxtPath = Path.Combine(totalOutput, "results.txt");
                 string totalTxtContent = ReportFormatter.BuildTextReport(totalLabel, totalReportData);
                 File.WriteAllText(totalTxtPath, totalTxtContent, Encoding.UTF8);
-                Console.Error.WriteLine($"전체 합산 리포트(TXT) 저장 완료: {totalTxtPath}");
+                Log.Information("전체 합산 리포트(TXT) 저장 완료: {TotalTxtPath}", totalTxtPath);
             }
 
             if (format == OutputFormat.Html)
@@ -361,12 +359,12 @@ await CoconaApp.RunAsync(async (
                 string totalHtmlPath = Path.Combine(totalOutput, "results.html");
                 string totalHtmlContent = ReportFormatter.BuildHtmlReport(totalLabel, totalReportData);
                 File.WriteAllText(totalHtmlPath, totalHtmlContent, Encoding.UTF8);
-                Console.Error.WriteLine($"전체 합산 HTML 리포트 저장 완료: {totalHtmlPath}");
+                Log.Information("전체 합산 HTML 리포트 저장 완료: {TotalHtmlPath}", totalHtmlPath);
             }
         }
         catch (Exception ex)
         {
-            AnsiConsole.WriteException(ex);
+            Log.Error(ex, "처리 중 예외가 발생했습니다.");
         }
     }
 });

--- a/Program.cs
+++ b/Program.cs
@@ -98,7 +98,7 @@ await CoconaApp.RunAsync(async (
                 // ── Claims 전용 모드 ──────────────────────────────────────────────────
                 if (claims != null)
                 {
-                    AnsiConsole.MarkupLine($"[[[blue]{ownerName}/{repoName}[/]]] 최근 이슈 선점 현황을 조회합니다...\n");
+                    Log.Information("[{Repo}] 최근 이슈 선점 현황을 조회합니다.", repo);
 
                     DateTimeOffset? claimsSince = (!noCache && cache.LastClaimsAnalyzedAt != DateTimeOffset.MinValue)
                         ? cache.LastClaimsAnalyzedAt
@@ -124,7 +124,7 @@ await CoconaApp.RunAsync(async (
                     return;
                 }
 
-                AnsiConsole.MarkupLine($"[yellow]{repo}[/] 기여자 데이터 수집 및 분석 중...");
+                Log.Information("[{Repo}] 기여자 데이터 수집 및 분석 중...", repo);
 
                 if (!Directory.Exists(repoOutput)) Directory.CreateDirectory(repoOutput);
 
@@ -276,7 +276,7 @@ await CoconaApp.RunAsync(async (
     {
         try
         {
-            AnsiConsole.MarkupLine($"\n[green]전체 저장소 합산 리포트 생성 중...[/]");
+            Log.Information("전체 저장소 합산 리포트 생성 중...");
 
             // 저장소별 결과를 순회하며 URL 기반 중복 제거 후 합산
             var totalUserIssues = new Dictionary<string, List<IssueRecord>>();


### PR DESCRIPTION
### ISSUE_ID

Refs #463

### 변경사항

- [x] 남아 있던 `Console.Error.WriteLine` 호출을 모두 `Log.*`로 교체했습니다.
- [x] 오류 메시지는 `Log.Error`로 변경했습니다.
- [x] 경고성 메시지는 `Log.Warning`으로 변경했습니다.
- [x] 캐시 상태, 저장 완료, 진행 메시지는 `Log.Information`으로 변경했습니다.
- [x] 예외 출력 `AnsiConsole.WriteException`을 `Log.Error(ex, ...)`로 변경했습니다.
- [x] 진행 메시지 `AnsiConsole.MarkupLine`도 `Log.Information`으로 정리했습니다.
- [x] 실제 결과 출력인 `Console.Write(report)`는 유지했습니다.

### 테스트 방법

```powershell
Get-ChildItem -Recurse -Filter *.cs | Select-String "Console\.Error"
Get-ChildItem -Recurse -Filter *.cs | Select-String "AnsiConsole\.WriteException"
Get-ChildItem -Recurse -Filter *.cs | Select-String "AnsiConsole\.MarkupLine"
dotnet format reposcore-cs.csproj --verify-no-changes --no-restore --include Program.cs Data/CacheManager.cs
dotnet build
```

위 검색 명령에서 잔여 호출이 없음을 확인했습니다.