### PR TITLE
기본 로그 레벨을 Information으로 재설정

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -24,14 +24,14 @@ await CoconaApp.RunAsync(async (
 [Option(Description = "정렬 방법")] SortOrder sortOrder = SortOrder.Desc,
 [Option(Description = "이슈 선점 키워드 (쉼표 구분, 미입력시 기본값 사용)", ValueName = "KEYWORDS")] string? keywords = null,
 [Option(Description = "캐시를 무시하고 전체 데이터를 다시 수집할지 여부")] bool noCache = false,
-[Option(Description = "로그 상세 수준 (0=기본, 1=진행 정보, 2=디버그, 3=상세 디버그)")] int verbose = 0
+[Option(Description = "로그 상세 수준 (-1=경고/에러만, 0=기본/진행 정보, 1=디버그, 2=상세 디버그)")] int verbose = 0
 ) =>
 {
     var minimumLevel = verbose switch
     {
-        <= 0 => LogEventLevel.Warning,
-        1 => LogEventLevel.Information,
-        2 => LogEventLevel.Debug,
+        < 0 => LogEventLevel.Warning,
+        0 => LogEventLevel.Information,
+        1 => LogEventLevel.Debug,
         _ => LogEventLevel.Verbose,
     };
 
@@ -368,6 +368,3 @@ await CoconaApp.RunAsync(async (
         }
     }
 });
-
-
-

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Options:
   --sort-order <SortOrder>       정렬 방법 (Default: Desc) (Allowed values: Asc, Desc)
   --keywords <KEYWORDS>          이슈 선점 키워드 (쉼표 구분, 미입력시 기본값 사용)
   --no-cache                     캐시를 무시하고 전체 데이터를 다시 수집할지 여부
-  --verbose <Int32>              로그 상세 수준 (0=기본, 1=진행 정보, 2=디버그, 3=상세 디버그) (Default: 0)
+  --verbose <Int32>              로그 상세 수준 (-1=경고/에러만, 0=기본/진행 정보, 1=디버그, 2=상세 디버그) (Default: 0)
   -h, --help                     Show help message
   --version                      Show version
 ```


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #490 

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- [ ] `Program.cs`의 `--verbose` 기본값(log level) 변경: `0`일 때 `LogEventLevel.Information`으로 설정
- [ ] `Program.cs`의 `--verbose` 스위치 로직 수정: `verbose < 0`은 `Warning`, `0`은 `Information`, `1`은 `Debug`, `>= 2`는 `Verbose`
- [ ] `README.md`의 `--verbose` 옵션 설명을 실제 동작에 맞게 업데이트

### 🧪 테스트 방법 (선택 사항)
dotnet run -- oss2026hnu/reposcore-cs oss2026hnu/reposcore-ts --format=txt 하여 info가 출력되는지 확인

### 💬 참고 사항 (선택 사항)
<!-- 리뷰 시 참고해야 할 내용이나 전달하고 싶은 사항이 있다면 작성해주세요 -->