### PR TITLE
HTML 레포트 막대그래프 기여건수 표시

### DIFF
--- a/Data/Reportformatter.cs
+++ b/Data/Reportformatter.cs
@@ -164,6 +164,7 @@ namespace RepoScore.Data
     <meta name=""viewport"" content=""width=device-width, initial-scale=1.0"">
     <title>RepoScore Report - {repoName}</title>
     <script src=""https://cdn.jsdelivr.net/npm/chart.js""></script>
+    <script src=""https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2.2.0""></script>
     <style>
         body {{ font-family: -apple-system, BlinkMacSystemFont, ""Segoe UI"", Helvetica, Arial, sans-serif, ""Apple Color Emoji"", ""Segoe UI Emoji""; margin: 2em; background-color: #f6f8fa; color: #24292e; }}
         h1 {{ border-bottom: 1px solid #e1e4e8; padding-bottom: 0.3em; }}
@@ -176,6 +177,7 @@ namespace RepoScore.Data
         <canvas id=""contributionChart""></canvas>
     </div>
     <script>
+        Chart.register(ChartDataLabels);
         const ctx = document.getElementById('contributionChart');
         new Chart(ctx, {{
             type: 'bar',
@@ -193,10 +195,28 @@ namespace RepoScore.Data
                 indexAxis: 'y',
                 responsive: true,
                 maintainAspectRatio: false,
-                scales: {{ x: {{ stacked: true }}, y: {{ stacked: true }} }},
+                scales: {{ 
+                    x: {{ 
+                        stacked: true,
+                        title: {{
+                            display: true,
+                            text: '기여 건수 (개)'
+                        }}
+                    }}, 
+                    y: {{ stacked: true }} 
+                }},
                 plugins: {{
-                    title: {{ display: true, text: '사용자별 기여 항목 분포' }},
-                    legend: {{ position: 'top' }}
+                    title: {{ display: true, text: '사용자별 기여 항목 분포 (그래프 내 기여 건수 표시)' }},
+                    legend: {{ position: 'top' }},
+                    datalabels: {{
+                        color: '#333',
+                        textStrokeColor: '#fff',
+                        textStrokeWidth: 2,
+                        font: {{ weight: 'bold' }},
+                        formatter: function(value) {{
+                            return value > 0 ? value : '';
+                        }}
+                    }}
                 }}
             }}
         }});


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #493 

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- [ ] HTML 레포트 막대그래프 기여건수 표시를 표시하도록 수정

### 🧪 테스트 방법 (선택 사항)
dotnet run -- oss2026hnu/reposcore-cs oss2026hnu/reposcore-ts --token {토큰} --format=html

위 명령어를 실행하고 아래 경로의 HTML 파일을 확인하여
막대그래프에 기여건수가 표시되는지 확인

./results/results.html

### 💬 참고 사항 (선택 사항)
CSV와 TXT의 통일성을 위해 막대그래프에 총점을 표시하는게 아닌
기여건수를 표시하고 총점은 아이디 옆에 보이도록 했습니다.
또한 정렬도 총점을 기준으로 했습니다.
