### PR TITLE
--format 옵션 다중 출력 형식 지정 기능 추가

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -18,7 +18,7 @@ await CoconaApp.RunAsync(async (
 [Argument(Description = "대상 저장소 목록 (예: owner/repo1 owner/repo2)")] string[] repos,
 [Option('t', Description = "GitHub Token (미입력시 GITHUB_TOKEN 사용)", ValueName = "TOKEN")] string? token = null,
 [Option(Description = "최근 이슈 선점 현황 조회")] ClaimsMode? claims = null,
-[Option('f', Description = "출력 형식 (쉼표 구분, 기본값: csv)")] string format = "csv",
+[Option('f', Description = "출력 형식 (쉼표 구분, 예: csv,txt 허용값: csv,txt,html)")] string format = "csv",
 [Option('o', Description = "출력 디렉토리 경로", ValueName = "DIR")] string output = "./results",
 [Option(Description = "정렬 기준")] SortBy sortBy = SortBy.Score,
 [Option(Description = "정렬 방법")] SortOrder sortOrder = SortOrder.Desc,

--- a/Program.cs
+++ b/Program.cs
@@ -27,18 +27,7 @@ await CoconaApp.RunAsync(async (
 [Option(Description = "로그 상세 수준 (-1=경고/에러만, 0=기본/진행 정보, 1=디버그, 2=상세 디버그)")] int verbose = 0
 ) =>
 {
-    // 입력받은 문자열을 쉼표로 분리하여 OutputFormat 열거형으로 변환 (대소문자 무시, 중복 제거)
-    var activeFormats = new HashSet<OutputFormat>();
-    foreach (var f in format.Split(','))
-    {
-        if (Enum.TryParse<OutputFormat>(f.Trim(), true, out var parsedFormat))
-        {
-            activeFormats.Add(parsedFormat);
-        }
-    }
-    if (activeFormats.Count == 0) activeFormats.Add(OutputFormat.Csv);
-
-    var minimumLevel = verbose switch
+    var minimumLevel = verbose switch // 로거 설정을 먼저 수행
     {
         < 0 => LogEventLevel.Warning,
         0 => LogEventLevel.Information,
@@ -52,6 +41,38 @@ await CoconaApp.RunAsync(async (
             standardErrorFromLevel: LogEventLevel.Verbose,
             outputTemplate: "[{Level:u3}] {Message:lj}{NewLine}{Exception}")
         .CreateLogger();
+
+    // --format 옵션 파싱 및 유효성 검사
+    var activeFormats = new HashSet<OutputFormat>();
+    var invalidFormats = new List<string>();
+    var allowedFormats = Enum.GetNames<OutputFormat>().Select(e => e.ToLowerInvariant());
+
+    foreach (var f in format.Split(',', StringSplitOptions.RemoveEmptyEntries))
+    {
+        var trimmedFormat = f.Trim();
+        if (string.IsNullOrEmpty(trimmedFormat)) continue;
+
+        if (Enum.TryParse<OutputFormat>(trimmedFormat, true, out var parsedFormat))
+        {
+            activeFormats.Add(parsedFormat);
+        }
+        else
+        {
+            invalidFormats.Add(trimmedFormat);
+        }
+    }
+
+    if (invalidFormats.Any())
+    {
+        foreach (var invalid in invalidFormats)
+            Log.Error("오류: '{Format}'은(는) 유효하지 않은 출력 형식입니다. 허용값: {Allowed}", invalid, string.Join(", ", allowedFormats));
+        Log.Error("도움말을 보려면 --help 옵션을 사용하세요.");
+        throw new CommandExitedException(1);
+    }
+
+    // 유효한 형식이 하나도 없으면 기본값(Csv) 사용
+    if (activeFormats.Count == 0) activeFormats.Add(OutputFormat.Csv);
+
     var formatErrors = new List<string>();
     foreach (var repo in repos)
     {

--- a/Program.cs
+++ b/Program.cs
@@ -18,7 +18,7 @@ await CoconaApp.RunAsync(async (
 [Argument(Description = "대상 저장소 목록 (예: owner/repo1 owner/repo2)")] string[] repos,
 [Option('t', Description = "GitHub Token (미입력시 GITHUB_TOKEN 사용)", ValueName = "TOKEN")] string? token = null,
 [Option(Description = "최근 이슈 선점 현황 조회")] ClaimsMode? claims = null,
-[Option('f', Description = "출력 형식")] OutputFormat format = OutputFormat.Csv,
+[Option('f', Description = "출력 형식 (쉼표 구분, 기본값: csv)")] string format = "csv",
 [Option('o', Description = "출력 디렉토리 경로", ValueName = "DIR")] string output = "./results",
 [Option(Description = "정렬 기준")] SortBy sortBy = SortBy.Score,
 [Option(Description = "정렬 방법")] SortOrder sortOrder = SortOrder.Desc,
@@ -27,6 +27,17 @@ await CoconaApp.RunAsync(async (
 [Option(Description = "로그 상세 수준 (-1=경고/에러만, 0=기본/진행 정보, 1=디버그, 2=상세 디버그)")] int verbose = 0
 ) =>
 {
+    // 입력받은 문자열을 쉼표로 분리하여 OutputFormat 열거형으로 변환 (대소문자 무시, 중복 제거)
+    var activeFormats = new HashSet<OutputFormat>();
+    foreach (var f in format.Split(','))
+    {
+        if (Enum.TryParse<OutputFormat>(f.Trim(), true, out var parsedFormat))
+        {
+            activeFormats.Add(parsedFormat);
+        }
+    }
+    if (activeFormats.Count == 0) activeFormats.Add(OutputFormat.Csv);
+
     var minimumLevel = verbose switch
     {
         < 0 => LogEventLevel.Warning,
@@ -68,7 +79,7 @@ await CoconaApp.RunAsync(async (
     string[]? parsedKeywords = keywords != null
         ? keywords.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
         : null;
-
+        
     // 저장소별 (issues, prs) 결과를 담을 딕셔너리 — 병렬 처리 후 합산에 사용
     var repoResults = new System.Collections.Concurrent.ConcurrentDictionary<string, (Dictionary<string, List<IssueRecord>> UserIssues, Dictionary<string, List<PRRecord>> UserPrs)>();
 
@@ -223,15 +234,18 @@ await CoconaApp.RunAsync(async (
 
                 reportData = ReportSorter.SortReportData(reportData, sortBy, sortOrder);
 
-                var csv = new StringBuilder();
-                csv.AppendLine("아이디, 문서이슈, 버그/기능이슈, 오타PR, 문서PR, 버그/기능PR, 총점");
-                foreach (var r in reportData) csv.AppendLine($"{r.Id}, {r.docIssues}, {r.featBugIssues}, {r.typoPrs}, {r.docPrs}, {r.featBugPrs}, {r.Score}");
+                if (activeFormats.Contains(OutputFormat.Csv))
+                {
+                    var csv = new StringBuilder();
+                    csv.AppendLine("아이디, 문서이슈, 버그/기능이슈, 오타PR, 문서PR, 버그/기능PR, 총점");
+                    foreach (var r in reportData) csv.AppendLine($"{r.Id}, {r.docIssues}, {r.featBugIssues}, {r.typoPrs}, {r.docPrs}, {r.featBugPrs}, {r.Score}");
 
-                string csvPath = Path.Combine(repoOutput, "results.csv");
-                File.WriteAllText(csvPath, csv.ToString(), Encoding.UTF8);
-                Log.Information("[{Repo}] 기본 데이터(CSV) 저장 완료: {CsvPath}", repo, csvPath);
+                    string csvPath = Path.Combine(repoOutput, "results.csv");
+                    File.WriteAllText(csvPath, csv.ToString(), Encoding.UTF8);
+                    Log.Information("[{Repo}] 기본 데이터(CSV) 저장 완료: {CsvPath}", repo, csvPath);
+                }
 
-                if (format == OutputFormat.Txt)
+                if (activeFormats.Contains(OutputFormat.Txt))
                 {
                     string txtPath = Path.Combine(repoOutput, "results.txt");
                     string txtContent = ReportFormatter.BuildTextReport(repo, reportData);
@@ -239,7 +253,7 @@ await CoconaApp.RunAsync(async (
                     Log.Information("[{Repo}] 가독성 리포트(TXT) 추가 저장 완료: {TxtPath}", repo, txtPath);
                 }
 
-                if (format == OutputFormat.Html)
+                if (activeFormats.Contains(OutputFormat.Html))
                 {
                     string htmlPath = Path.Combine(repoOutput, "results.html");
                     string htmlContent = ReportFormatter.BuildHtmlReport(repo, reportData);
@@ -336,15 +350,18 @@ await CoconaApp.RunAsync(async (
             string totalOutput = output;
             if (!Directory.Exists(totalOutput)) Directory.CreateDirectory(totalOutput);
 
-            var totalCsv = new StringBuilder();
-            totalCsv.AppendLine("아이디, 문서이슈, 버그/기능이슈, 오타PR, 문서PR, 버그/기능PR, 총점");
-            foreach (var r in totalReportData) totalCsv.AppendLine($"{r.Id}, {r.docIssues}, {r.featBugIssues}, {r.typoPrs}, {r.docPrs}, {r.featBugPrs}, {r.Score}");
+            if (activeFormats.Contains(OutputFormat.Csv))
+            {
+                var totalCsv = new StringBuilder();
+                totalCsv.AppendLine("아이디, 문서이슈, 버그/기능이슈, 오타PR, 문서PR, 버그/기능PR, 총점");
+                foreach (var r in totalReportData) totalCsv.AppendLine($"{r.Id}, {r.docIssues}, {r.featBugIssues}, {r.typoPrs}, {r.docPrs}, {r.featBugPrs}, {r.Score}");
 
-            string totalCsvPath = Path.Combine(totalOutput, "results.csv");
-            File.WriteAllText(totalCsvPath, totalCsv.ToString(), Encoding.UTF8);
-            Log.Information("전체 합산 데이터(CSV) 저장 완료: {TotalCsvPath}", totalCsvPath);
+                string totalCsvPath = Path.Combine(totalOutput, "results.csv");
+                File.WriteAllText(totalCsvPath, totalCsv.ToString(), Encoding.UTF8);
+                Log.Information("전체 합산 데이터(CSV) 저장 완료: {TotalCsvPath}", totalCsvPath);
+            }
 
-            if (format == OutputFormat.Txt)
+            if (activeFormats.Contains(OutputFormat.Txt))
             {
                 string totalLabel = string.Join(" + ", repos);
                 string totalTxtPath = Path.Combine(totalOutput, "results.txt");
@@ -353,7 +370,7 @@ await CoconaApp.RunAsync(async (
                 Log.Information("전체 합산 리포트(TXT) 저장 완료: {TotalTxtPath}", totalTxtPath);
             }
 
-            if (format == OutputFormat.Html)
+            if (activeFormats.Contains(OutputFormat.Html))
             {
                 string totalLabel = string.Join(" + ", repos);
                 string totalHtmlPath = Path.Combine(totalOutput, "results.html");

--- a/Program.cs
+++ b/Program.cs
@@ -79,7 +79,7 @@ await CoconaApp.RunAsync(async (
     string[]? parsedKeywords = keywords != null
         ? keywords.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
         : null;
-        
+
     // 저장소별 (issues, prs) 결과를 담을 딕셔너리 — 병렬 처리 후 합산에 사용
     var repoResults = new System.Collections.Concurrent.ConcurrentDictionary<string, (Dictionary<string, List<IssueRecord>> UserIssues, Dictionary<string, List<PRRecord>> UserPrs)>();
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ dotnet run -- --help
 ## Synopsis
 
 ```text
-Usage: reposcore-cs [--token <TOKEN>] [--claims <ClaimsMode>] [--format <OutputFormat>] [--output <DIR>] [--sort-by <SortBy>] [--sort-order <SortOrder>] [--keywords <KEYWORDS>] [--no-cache] [--verbose <Int32>] [--help] [--version] repos0 ... reposN
+Usage: reposcore-cs [--token <TOKEN>] [--claims <ClaimsMode>] [--format <String>] [--output <DIR>] [--sort-by <SortBy>] [--sort-order <SortOrder>] [--keywords <KEYWORDS>] [--no-cache] [--verbose <Int32>] [--help] [--version] repos0 ... reposN
 
 reposcore-cs
 
@@ -48,17 +48,17 @@ Arguments:
   0: repos    대상 저장소 목록 (예: owner/repo1 owner/repo2) (Required)
 
 Options:
-  -t, --token <TOKEN>            GitHub Token (미입력시 GITHUB_TOKEN 사용)
-  --claims <ClaimsMode>          최근 이슈 선점 현황 조회 (Allowed values: Issue, User)
-  -f, --format <OutputFormat>    출력 형식 (Default: Csv) (Allowed values: Csv, Txt, Html)
-  -o, --output <DIR>             출력 디렉토리 경로 (Default: ./results)
-  --sort-by <SortBy>             정렬 기준 (Default: Score) (Allowed values: Score, Id)
-  --sort-order <SortOrder>       정렬 방법 (Default: Desc) (Allowed values: Asc, Desc)
-  --keywords <KEYWORDS>          이슈 선점 키워드 (쉼표 구분, 미입력시 기본값 사용)
-  --no-cache                     캐시를 무시하고 전체 데이터를 다시 수집할지 여부
-  --verbose <Int32>              로그 상세 수준 (-1=경고/에러만, 0=기본/진행 정보, 1=디버그, 2=상세 디버그) (Default: 0)
-  -h, --help                     Show help message
-  --version                      Show version
+  -t, --token <TOKEN>         GitHub Token (미입력시 GITHUB_TOKEN 사용)
+  --claims <ClaimsMode>       최근 이슈 선점 현황 조회 (Allowed values: Issue, User)
+  -f, --format <String>       출력 형식 (쉼표 구분, 예: csv,txt 허용값: csv,txt,html) (Default: csv)
+  -o, --output <DIR>          출력 디렉토리 경로 (Default: ./results)
+  --sort-by <SortBy>          정렬 기준 (Default: Score) (Allowed values: Score, Id)
+  --sort-order <SortOrder>    정렬 방법 (Default: Desc) (Allowed values: Asc, Desc)
+  --keywords <KEYWORDS>       이슈 선점 키워드 (쉼표 구분, 미입력시 기본값 사용)
+  --no-cache                  캐시를 무시하고 전체 데이터를 다시 수집할지 여부
+  --verbose <Int32>           로그 상세 수준 (-1=경고/에러만, 0=기본/진행 정보, 1=디버그, 2=상세 디버그) (Default: 0)
+  -h, --help                  Show help message
+  --version                   Show version
 ```
 
 ## Synopsis 업데이트


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #498 

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- [ ] --format 옵션 다중 출력 형식 지정 기능 추가 (예: --format=csv,txt)
- [ ] 다중 형식 지정에 따른 결과 출력 로직 수정
- [ ] sysnopsis 변경에 따른 README.md 파일 업데이트

### 🧪 테스트 방법 (선택 사항)
dotnet run -- oss2026hnu/reposcore-cs oss2026hnu/reposcore-ts --token {토큰} --format html,csv,txt --no-cache

위 명령어를 실행하여 csv, txt, html 파일 세개가 생성되는지 확인

### 💬 참고 사항 (선택 사항)
, 쉼표 구분을 통한 형식 지정을 위해 format 옵션을 string으로 변경하였습니다.