### PR TITLE
중복되는 코드 리팩토링

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -36,7 +36,7 @@ await CoconaApp.RunAsync(async (
             standardErrorFromLevel: LogEventLevel.Verbose,
             outputTemplate: "[{Level:u3}] {Message:lj}{NewLine}{Exception}")
         .CreateLogger();
-    
+
     // --format 옵션 파싱 및 유효성 검사
     var activeFormats = new HashSet<OutputFormat>();
     var invalidFormats = new List<string>();

--- a/Program.cs
+++ b/Program.cs
@@ -22,7 +22,7 @@ await CoconaApp.RunAsync(async (
 [Option(Description = "로그 상세 수준 (-1=경고/에러만, 0=기본/진행 정보, 1=디버그, 2=상세 디버그)")] int verbose = 0
 ) =>
 {
-    var minimumLevel = verbose switch // 로거 설정을 먼저 수행
+    var minimumLevel = verbose switch
     {
         < 0 => LogEventLevel.Warning,
         0 => LogEventLevel.Information,
@@ -56,6 +56,7 @@ await CoconaApp.RunAsync(async (
             invalidFormats.Add(trimmedFormat);
         }
     }
+
 
     if (invalidFormats.Any())
     {
@@ -125,7 +126,6 @@ await CoconaApp.RunAsync(async (
 
             try
             {
-                // ── Claims 전용 모드 ──────────────────────────────────────────────────
                 if (claims != null)
                 {
                     Log.Information("[{Repo}] 최근 이슈 선점 현황을 조회합니다.", repo);
@@ -253,32 +253,8 @@ await CoconaApp.RunAsync(async (
 
                 reportData = ReportSorter.SortReportData(reportData, sortBy, sortOrder);
 
-                if (activeFormats.Contains(OutputFormat.Csv))
-                {
-                    var csv = new StringBuilder();
-                    csv.AppendLine("아이디, 문서이슈, 버그/기능이슈, 오타PR, 문서PR, 버그/기능PR, 총점");
-                    foreach (var r in reportData) csv.AppendLine($"{r.Id}, {r.docIssues}, {r.featBugIssues}, {r.typoPrs}, {r.docPrs}, {r.featBugPrs}, {r.Score}");
-
-                    string csvPath = Path.Combine(repoOutput, "results.csv");
-                    File.WriteAllText(csvPath, csv.ToString(), Encoding.UTF8);
-                    Log.Information("[{Repo}] 기본 데이터(CSV) 저장 완료: {CsvPath}", repo, csvPath);
-                }
-
-                if (activeFormats.Contains(OutputFormat.Txt))
-                {
-                    string txtPath = Path.Combine(repoOutput, "results.txt");
-                    string txtContent = ReportFormatter.BuildTextReport(repo, reportData);
-                    File.WriteAllText(txtPath, txtContent, Encoding.UTF8);
-                    Log.Information("[{Repo}] 가독성 리포트(TXT) 추가 저장 완료: {TxtPath}", repo, txtPath);
-                }
-
-                if (activeFormats.Contains(OutputFormat.Html))
-                {
-                    string htmlPath = Path.Combine(repoOutput, "results.html");
-                    string htmlContent = ReportFormatter.BuildHtmlReport(repo, reportData);
-                    File.WriteAllText(htmlPath, htmlContent, Encoding.UTF8);
-                    Log.Information("[{Repo}] HTML 리포트 추가 저장 완료: {HtmlPath}", repo, htmlPath);
-                }
+                // ── 1. 리팩토링 포인트: 개별 저장소 리포트 출력 ──
+                ExportReports(repo, reportData, activeFormats, repoOutput);
 
                 if (repos.Length > 1)
                 {
@@ -295,7 +271,6 @@ await CoconaApp.RunAsync(async (
                     return;
                 }
 
-                // 저장소 처리 실패를 기록하고 다른 저장소 처리는 계속 진행
                 Log.Error(ex, "[{Repo}] 처리 중 예외가 발생했습니다.", repo);
                 repoFailures.Add(repo);
             }
@@ -317,41 +292,17 @@ await CoconaApp.RunAsync(async (
         {
             Log.Information("전체 저장소 합산 리포트 생성 중...");
 
-            // 저장소별 결과를 순회하며 URL 기반 중복 제거 후 합산
             var totalUserIssues = new Dictionary<string, List<IssueRecord>>();
             var totalUserPullRequests = new Dictionary<string, List<PRRecord>>();
 
             foreach (var (_, (userIssues, userPrs)) in repoResults)
             {
-                foreach (var (user, issues) in userIssues)
-                {
-                    if (!totalUserIssues.ContainsKey(user)) totalUserIssues[user] = new List<IssueRecord>();
-                    foreach (var issue in issues)
-                    {
-                        bool isDuplicate = string.IsNullOrEmpty(issue.Url)
-                            ? totalUserIssues[user].Any(i => string.IsNullOrEmpty(i.Url) && i.Number == issue.Number)
-                            : totalUserIssues[user].Any(i => i.Url == issue.Url);
-                        if (!isDuplicate)
-                            totalUserIssues[user].Add(issue);
-                    }
-                }
-
-                foreach (var (user, prs) in userPrs)
-                {
-                    if (!totalUserPullRequests.ContainsKey(user)) totalUserPullRequests[user] = new List<PRRecord>();
-                    foreach (var pr in prs)
-                    {
-                        bool isDuplicate = string.IsNullOrEmpty(pr.Url)
-                            ? totalUserPullRequests[user].Any(p => string.IsNullOrEmpty(p.Url) && p.Number == pr.Number)
-                            : totalUserPullRequests[user].Any(p => p.Url == pr.Url);
-                        if (!isDuplicate)
-                            totalUserPullRequests[user].Add(pr);
-                    }
-                }
+                // ── 제네릭 함수를 활용한 병합 로직 단일화 ──
+                MergeUserRecords(totalUserIssues, userIssues, i => i.Url, i => i.Number);
+                MergeUserRecords(totalUserPullRequests, userPrs, p => p.Url, p => p.Number);
             }
 
             var totalReportData = new List<(string Id, int docIssues, int featBugIssues, int typoPrs, int docPrs, int featBugPrs, int Score)>();
-
             var allUsers = totalUserIssues.Keys.Union(totalUserPullRequests.Keys).ToList();
 
             foreach (var user in allUsers)
@@ -372,41 +323,12 @@ await CoconaApp.RunAsync(async (
 
             totalReportData = ReportSorter.SortReportData(totalReportData, sortBy, sortOrder);
 
-            string totalOutput = output;
-            if (!Directory.Exists(totalOutput)) Directory.CreateDirectory(totalOutput);
-
-            if (activeFormats.Contains(OutputFormat.Csv))
-            {
-                var totalCsv = new StringBuilder();
-                totalCsv.AppendLine("아이디, 문서이슈, 버그/기능이슈, 오타PR, 문서PR, 버그/기능PR, 총점");
-                foreach (var r in totalReportData) totalCsv.AppendLine($"{r.Id}, {r.docIssues}, {r.featBugIssues}, {r.typoPrs}, {r.docPrs}, {r.featBugPrs}, {r.Score}");
-
-                string totalCsvPath = Path.Combine(totalOutput, "results.csv");
-                File.WriteAllText(totalCsvPath, totalCsv.ToString(), Encoding.UTF8);
-                Log.Information("전체 합산 데이터(CSV) 저장 완료: {TotalCsvPath}", totalCsvPath);
-            }
-
-            if (activeFormats.Contains(OutputFormat.Txt))
-            {
-                string totalLabel = string.Join(" + ", repos);
-                string totalTxtPath = Path.Combine(totalOutput, "results.txt");
-                string totalTxtContent = ReportFormatter.BuildTextReport(totalLabel, totalReportData);
-                File.WriteAllText(totalTxtPath, totalTxtContent, Encoding.UTF8);
-                Log.Information("전체 합산 리포트(TXT) 저장 완료: {TotalTxtPath}", totalTxtPath);
-            }
-
-            if (activeFormats.Contains(OutputFormat.Html))
-            {
-                string totalLabel = string.Join(" + ", repos);
-                string totalHtmlPath = Path.Combine(totalOutput, "results.html");
-                string totalHtmlContent = ReportFormatter.BuildHtmlReport(totalLabel, totalReportData);
-                File.WriteAllText(totalHtmlPath, totalHtmlContent, Encoding.UTF8);
-                Log.Information("전체 합산 HTML 리포트 저장 완료: {TotalHtmlPath}", totalHtmlPath);
-            }
+            // ── 전체 합산 리포트 출력 ──
+            string totalLabel = string.Join(" + ", repos);
+            ExportReports(totalLabel, totalReportData, activeFormats, output);
         }
         catch (Exception ex)
         {
-            // 합산 단계 실패도 비 0 종료로 처리
             Log.Error(ex, "합산 리포트 생성 중 예외가 발생했습니다.");
             throw new CommandExitedException(1);
         }
@@ -420,3 +342,75 @@ await CoconaApp.RunAsync(async (
         throw new CommandExitedException(1);
     }
 });
+
+// CSV, TXT, HTML 서식에 맞춰 리포트 파일을 물리 디렉토리에 내보내는 공통 메서드
+
+static void ExportReports(
+    string label,
+    List<(string Id, int docIssues, int featBugIssues, int typoPrs, int docPrs, int featBugPrs, int Score)> reportData,
+    HashSet<OutputFormat> activeFormats,
+    string outputDir)
+{
+    if (!Directory.Exists(outputDir)) Directory.CreateDirectory(outputDir);
+
+    if (activeFormats.Contains(OutputFormat.Csv))
+    {
+        var csv = new StringBuilder();
+        csv.AppendLine("아이디, 문서이슈, 버그/기능이슈, 오타PR, 문서PR, 버그/기능PR, 총점");
+        foreach (var r in reportData)
+            csv.AppendLine($"{r.Id}, {r.docIssues}, {r.featBugIssues}, {r.typoPrs}, {r.docPrs}, {r.featBugPrs}, {r.Score}");
+
+        string csvPath = Path.Combine(outputDir, "results.csv");
+        File.WriteAllText(csvPath, csv.ToString(), Encoding.UTF8);
+        Log.Information("[{Label}] 데이터(CSV) 저장 완료: {CsvPath}", label, csvPath);
+    }
+
+    if (activeFormats.Contains(OutputFormat.Txt))
+    {
+        string txtPath = Path.Combine(outputDir, "results.txt");
+        string txtContent = ReportFormatter.BuildTextReport(label, reportData);
+        File.WriteAllText(txtPath, txtContent, Encoding.UTF8);
+        Log.Information("[{Label}] 가독성 리포트(TXT) 저장 완료: {TxtPath}", label, txtPath);
+    }
+
+    if (activeFormats.Contains(OutputFormat.Html))
+    {
+        string htmlPath = Path.Combine(outputDir, "results.html");
+        string htmlContent = ReportFormatter.BuildHtmlReport(label, reportData);
+        File.WriteAllText(htmlPath, htmlContent, Encoding.UTF8);
+        Log.Information("[{Label}] HTML 리포트 저장 완료: {HtmlPath}", label, htmlPath);
+    }
+}
+
+// 제네릭(Generic)과 람다 선택자를 이용해 이슈와 PR 구분 없이 URL/Number 기반 중복을 제거하며 데이터를 합산하는 메서드
+static void MergeUserRecords<T>(
+    Dictionary<string, List<T>> target,
+    Dictionary<string, List<T>> source,
+    Func<T, string?> urlSelector,
+    Func<T, int> numberSelector)
+{
+    foreach (var (user, items) in source)
+    {
+        if (!target.TryGetValue(user, out var targetList))
+        {
+            targetList = new List<T>();
+            target[user] = targetList;
+        }
+
+        foreach (var item in items)
+        {
+            string? url = urlSelector(item);
+            int number = numberSelector(item);
+
+            // URL이 없으면 Number로 비교, URL이 있으면 URL 문자열 자체로 중복 검사
+            bool isDuplicate = string.IsNullOrEmpty(url)
+                ? targetList.Any(t => string.IsNullOrEmpty(urlSelector(t)) && numberSelector(t) == number)
+                : targetList.Any(t => urlSelector(t) == url);
+
+            if (!isDuplicate)
+            {
+                targetList.Add(item);
+            }
+        }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -36,7 +36,7 @@ await CoconaApp.RunAsync(async (
             standardErrorFromLevel: LogEventLevel.Verbose,
             outputTemplate: "[{Level:u3}] {Message:lj}{NewLine}{Exception}")
         .CreateLogger();
-
+    
     // --format 옵션 파싱 및 유효성 검사
     var activeFormats = new HashSet<OutputFormat>();
     var invalidFormats = new List<string>();
@@ -57,7 +57,6 @@ await CoconaApp.RunAsync(async (
         }
     }
 
-
     if (invalidFormats.Any())
     {
         foreach (var invalid in invalidFormats)
@@ -66,7 +65,6 @@ await CoconaApp.RunAsync(async (
         throw new CommandExitedException(1);
     }
 
-    // 유효한 형식이 하나도 없으면 기본값(Csv) 사용
     if (activeFormats.Count == 0) activeFormats.Add(OutputFormat.Csv);
 
     var formatErrors = new List<string>();
@@ -97,13 +95,9 @@ await CoconaApp.RunAsync(async (
         ? keywords.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
         : null;
 
-    // 저장소별 (issues, prs) 결과를 담을 딕셔너리 — 병렬 처리 후 합산에 사용
     var repoResults = new System.Collections.Concurrent.ConcurrentDictionary<string, (Dictionary<string, List<IssueRecord>> UserIssues, Dictionary<string, List<PRRecord>> UserPrs)>();
-
-    // 저장소 처리 중 발생한 예외를 저장 — Task.WhenAll 후 종료 코드 결정에 사용
     var repoFailures = new System.Collections.Concurrent.ConcurrentBag<string>();
 
-    // 다중 저장소를 병렬로 처리 (동시 실행 상한: 8)
     using var semaphore = new System.Threading.SemaphoreSlim(8);
 
     var repoTasks = repos.Select(async repo =>
@@ -178,7 +172,6 @@ await CoconaApp.RunAsync(async (
                 else
                     Log.Information("[{Repo}] 기존 캐시 없음: 전체 데이터를 수집합니다.", repo);
 
-                // PR과 이슈를 병렬로 조회
                 var prsTask = service.GetPullRequestsAsync(since);
                 var issuesTask = service.GetIssuesAsync(since);
                 await Task.WhenAll(prsTask, issuesTask);
@@ -201,8 +194,6 @@ await CoconaApp.RunAsync(async (
                 }
 
                 var reportData = new List<(string Id, int docIssues, int featBugIssues, int typoPrs, int docPrs, int featBugPrs, int Score)>();
-
-                // 저장소별 집계용 (합산에 사용)
                 var repoUserIssues = new Dictionary<string, List<IssueRecord>>();
                 var repoUserPrs = new Dictionary<string, List<PRRecord>>();
 
@@ -283,7 +274,6 @@ await CoconaApp.RunAsync(async (
 
     await Task.WhenAll(repoTasks);
 
-    // 하나 이상의 저장소 처리가 실패한 경우 합산 리포트는 진행하되 마지막에 비 0 종료
     bool hasRepoFailure = !repoFailures.IsEmpty;
 
     if (repos.Length > 1 && repoResults.Count > 0)
@@ -297,9 +287,8 @@ await CoconaApp.RunAsync(async (
 
             foreach (var (_, (userIssues, userPrs)) in repoResults)
             {
-                // ── 제네릭 함수를 활용한 병합 로직 단일화 ──
-                MergeUserRecords(totalUserIssues, userIssues, i => i.Url, i => i.Number);
-                MergeUserRecords(totalUserPullRequests, userPrs, p => p.Url, p => p.Number);
+                MergeUserRecords(totalUserIssues, userIssues);
+                MergeUserRecords(totalUserPullRequests, userPrs);
             }
 
             var totalReportData = new List<(string Id, int docIssues, int featBugIssues, int typoPrs, int docPrs, int featBugPrs, int Score)>();
@@ -323,7 +312,6 @@ await CoconaApp.RunAsync(async (
 
             totalReportData = ReportSorter.SortReportData(totalReportData, sortBy, sortOrder);
 
-            // ── 전체 합산 리포트 출력 ──
             string totalLabel = string.Join(" + ", repos);
             ExportReports(totalLabel, totalReportData, activeFormats, output);
         }
@@ -334,7 +322,6 @@ await CoconaApp.RunAsync(async (
         }
     }
 
-    // 개별 저장소 처리 실패가 있었던 경우 비 0 종료
     if (hasRepoFailure)
     {
         var failedRepos = string.Join(", ", repoFailures);
@@ -343,8 +330,10 @@ await CoconaApp.RunAsync(async (
     }
 });
 
-// CSV, TXT, HTML 서식에 맞춰 리포트 파일을 물리 디렉토리에 내보내는 공통 메서드
 
+/// <summary>
+/// CSV, TXT, HTML 서식에 맞춰 리포트 파일을 물리 디렉토리에 내보내는 공통 메서드
+/// </summary>
 static void ExportReports(
     string label,
     List<(string Id, int docIssues, int featBugIssues, int typoPrs, int docPrs, int featBugPrs, int Score)> reportData,
@@ -382,12 +371,9 @@ static void ExportReports(
     }
 }
 
-// 제네릭(Generic)과 람다 선택자를 이용해 이슈와 PR 구분 없이 URL/Number 기반 중복을 제거하며 데이터를 합산하는 메서드
 static void MergeUserRecords<T>(
     Dictionary<string, List<T>> target,
-    Dictionary<string, List<T>> source,
-    Func<T, string?> urlSelector,
-    Func<T, int> numberSelector)
+    Dictionary<string, List<T>> source)
 {
     foreach (var (user, items) in source)
     {
@@ -399,13 +385,20 @@ static void MergeUserRecords<T>(
 
         foreach (var item in items)
         {
-            string? url = urlSelector(item);
-            int number = numberSelector(item);
+            bool isDuplicate = false;
 
-            // URL이 없으면 Number로 비교, URL이 있으면 URL 문자열 자체로 중복 검사
-            bool isDuplicate = string.IsNullOrEmpty(url)
-                ? targetList.Any(t => string.IsNullOrEmpty(urlSelector(t)) && numberSelector(t) == number)
-                : targetList.Any(t => urlSelector(t) == url);
+            if (item is IssueRecord issue)
+            {
+                isDuplicate = string.IsNullOrEmpty(issue.Url)
+                    ? targetList.Any(t => t is IssueRecord i && string.IsNullOrEmpty(i.Url) && i.Number == issue.Number)
+                    : targetList.Any(t => t is IssueRecord i && i.Url == issue.Url);
+            }
+            else if (item is PRRecord pr)
+            {
+                isDuplicate = string.IsNullOrEmpty(pr.Url)
+                    ? targetList.Any(t => t is PRRecord p && string.IsNullOrEmpty(p.Url) && p.Number == pr.Number)
+                    : targetList.Any(t => t is PRRecord p && p.Url == pr.Url);
+            }
 
             if (!isDuplicate)
             {


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes # 484

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- [ ] 출력 로직 공통 함수화: 개별 저장소 처리부와 다중 저장소 합산 처리부에서 중복되던 CSV, TXT, HTML 파일 생성 및 저장 로직을 ExportReports 공통 헬퍼 메서드로 추출하여 코드 중복 제거
- [ ] 제네릭 기반 병합 로직 단일화: 구조가 완전히 동일했던 IssueRecord와 PRRecord 데이터의 URL/Number 기반 중복 제거 및 병합 루프를 C# 제네릭을 활용한 MergeUserRecords<T> 단일 메서드로 통합

### 🧪 테스트 방법 (선택 사항)
<!-- 변경 사항이 정상 동작하는지 어떻게 확인했는지 작성해주세요 -->

### 💬 참고 사항 (선택 사항)
<!-- 리뷰 시 참고해야 할 내용이나 전달하고 싶은 사항이 있다면 작성해주세요 -->
