### PR TITLE
repo 입력 검증을ValidateRepositoriesAsync로 통합(형식+존재, alias 단일 쿼리)

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -67,26 +67,32 @@ await CoconaApp.RunAsync(async (
 
     if (activeFormats.Count == 0) activeFormats.Add(OutputFormat.Csv);
 
-    var formatErrors = new List<string>();
-    foreach (var repo in repos)
-    {
-        var parts = repo.Split('/');
-        if (parts.Length != 2 || string.IsNullOrWhiteSpace(parts[0]) || string.IsNullOrWhiteSpace(parts[1]))
-            formatErrors.Add($"오류: '{repo}'는 'owner/repo' 형식이 아닙니다.");
-    }
-
-    if (formatErrors.Count > 0)
-    {
-        foreach (var error in formatErrors)
-            Log.Error("{Error}", error);
-        Log.Error("도움말을 보려면 --help 옵션을 사용하세요.");
-        throw new CommandExitedException(1);
-    }
-
+    // 토큰 확인 단계를 위로 이동 (저장소 존재 여부 네트워크 검증에 필수적이기 때문)
     token ??= Environment.GetEnvironmentVariable("GITHUB_TOKEN");
     if (string.IsNullOrEmpty(token))
     {
         Log.Error("오류: GitHub 토큰이 필요합니다.");
+        Log.Error("도움말을 보려면 --help 옵션을 사용하세요.");
+        throw new CommandExitedException(1);
+    }
+
+    // [리팩토링 포인트] 1단계&2단계: 저장소 유효성(형식 + 실제 존재 여부) 일괄 사전 검증
+    var (malformed, notFound) = await GitHubService.ValidateRepositoriesAsync(repos, token);
+
+    if (malformed.Count > 0)
+    {
+        foreach (var r in malformed)
+            Log.Error("오류: '{Repo}'는 'owner/repo' 형식이 아닙니다.", r);
+    }
+
+    if (notFound.Count > 0)
+    {
+        foreach (var r in notFound)
+            Log.Error("오류: '{Repo}' 저장소가 존재하지 않거나 접근할 수 없습니다. 이름 오타가 아닌지 확인해 주세요.", r);
+    }
+
+    if (malformed.Count > 0 || notFound.Count > 0)
+    {
         Log.Error("도움말을 보려면 --help 옵션을 사용하세요.");
         throw new CommandExitedException(1);
     }
@@ -244,7 +250,7 @@ await CoconaApp.RunAsync(async (
 
                 reportData = ReportSorter.SortReportData(reportData, sortBy, sortOrder);
 
-                // ── 1. 리팩토링 포인트: 개별 저장소 리포트 출력 ──
+                // ── 개별 저장소 리포트 출력 ──
                 ExportReports(repo, reportData, activeFormats, repoOutput);
 
                 if (repos.Length > 1)
@@ -254,14 +260,7 @@ await CoconaApp.RunAsync(async (
             }
             catch (Exception ex)
             {
-                if (ex.Message.Contains("Could not resolve to a Repository") ||
-                    (ex.InnerException?.Message.Contains("Could not resolve to a Repository") == true))
-                {
-                    Log.Error("오류: '{Repo}' 저장소가 존재하지 않거나 접근할 수 없습니다.", repo);
-                    Environment.Exit(1);
-                    return;
-                }
-
+                // [리팩토링 포인트] 수집 단단으로 존재 검증을 옮겼으므로, 강제 중단(Environment.Exit) 분기를 지우고 일관되게 repoFailures 처리
                 Log.Error(ex, "[{Repo}] 처리 중 예외가 발생했습니다.", repo);
                 repoFailures.Add(repo);
             }

--- a/Services/GitHubService.cs
+++ b/Services/GitHubService.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
@@ -216,6 +217,80 @@ namespace RepoScore.Services
         }
 
         /// <summary>
+        /// [리팩토링 포인트] 데이터 수집 전 저장소의 형식 및 실제 존재 여부를 GraphQL Alias를 사용해 1회 요청으로 일괄 확인합니다.
+        /// </summary>
+        public static async System.Threading.Tasks.Task<(List<string> Malformed, List<string> NotFound)> ValidateRepositoriesAsync(string[] repos, string token)
+        {
+            var malformed = new List<string>();
+            var notFound = new List<string>();
+            var validRepos = new List<(string Owner, string RepoName, string Original)>();
+
+            // 1단계: 로컬 형식 검증
+            foreach (var repo in repos)
+            {
+                if (string.IsNullOrWhiteSpace(repo))
+                {
+                    malformed.Add(repo);
+                    continue;
+                }
+
+                var parts = repo.Split('/');
+                if (parts.Length != 2 || string.IsNullOrWhiteSpace(parts[0]) || string.IsNullOrWhiteSpace(parts[1]))
+                {
+                    malformed.Add(repo);
+                }
+                else
+                {
+                    validRepos.Add((parts[0], parts[1], repo));
+                }
+            }
+
+            // 2단계: 네트워크 존재 검증 (GraphQL Alias 단일 쿼리 구성)
+            if (validRepos.Count > 0)
+            {
+                var queryBuilder = new StringBuilder();
+                queryBuilder.AppendLine("query {");
+                for (int i = 0; i < validRepos.Count; i++)
+                {
+                    queryBuilder.AppendLine($"  r{i}: repository(owner: \"{validRepos[i].Owner}\", name: \"{validRepos[i].RepoName}\") {{ id }}");
+                }
+                queryBuilder.AppendLine("}");
+
+                var connection = new Octokit.GraphQL.Connection(new Octokit.GraphQL.ProductHeaderValue("reposcore-cs"), token);
+                var requestPayload = JsonSerializer.Serialize(new { query = queryBuilder.ToString() });
+
+                try
+                {
+                    var rawResponse = await connection.Run(requestPayload);
+                    using var document = JsonDocument.Parse(rawResponse);
+
+                    if (document.RootElement.TryGetProperty("data", out var dataElement))
+                    {
+                        for (int i = 0; i < validRepos.Count; i++)
+                        {
+                            string alias = $"r{i}";
+                            // 부분 실패 시 해당 alias 필드는 응답 json 내에서 null로 떨어집니다.
+                            if (!dataElement.TryGetProperty(alias, out var repoElement) || repoElement.ValueKind == JsonValueKind.Null)
+                            {
+                                notFound.Add(validRepos[i].Original);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        foreach (var vr in validRepos) notFound.Add(vr.Original);
+                    }
+                }
+                catch (Exception)
+                {
+                    foreach (var vr in validRepos) notFound.Add(vr.Original);
+                }
+            }
+
+            return (malformed, notFound);
+        }
+
+        /// <summary>
         /// 저장소 내에서 메인 브랜치에 병합(Merged)이 완료된 전체 Pull Request 목록을 GraphQL로 비동기 조회합니다.
         /// </summary>
         /// <param name="since">지정된 경우, 해당 일시 이후에 최종 업데이트된 Pull Request 데이터만 필터링하여 수집합니다.</param>
@@ -284,11 +359,9 @@ namespace RepoScore.Services
         /// <exception cref="InvalidOperationException">저장소가 존재하지 않거나 GitHub API 측에서 오류 응답을 반환할 때 발생합니다.</exception>
         public async System.Threading.Tasks.Task<List<IssueRecord>> GetIssuesAsync(DateTimeOffset? since = null)
         {
+            // [리팩토링 포인트] 불필요한 중복 존재 검증 블록인 repository(owner, name) { id } 제거 및 검색 쿼리 단일화
             const string rawGraphQl = @"
-            query($owner: String!, $repoName: String!, $searchQuery: String!, $after: String) {
-                repository(owner: $owner, name: $repoName) {
-                    id
-                }
+            query($searchQuery: String!, $after: String) {
                 search(query: $searchQuery, type: ISSUE, first: 100, after: $after) {
                     pageInfo {
                         hasNextPage
@@ -331,8 +404,6 @@ namespace RepoScore.Services
                     query = rawGraphQl,
                     variables = new Dictionary<string, object?>
                     {
-                        ["owner"] = _owner,
-                        ["repoName"] = _repo,
                         ["searchQuery"] = searchString,
                         ["after"] = cursor
                     }


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #508

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- [ ] 저장소 유효성 사전 일괄 검증 (Services/GitHubService.cs): ValidateRepositoriesAsync 메서드를 추가하여, 데이터 수집 스레드가 시작되기 전에 GraphQL Alias를 통해 단 1번의 네트워크 요청만으로 모든 저장소의 형식 및 실제 존재 여부를 검증하도록 개선
- [ ] 불필요한 중복 쿼리 제거 (Services/GitHubService.cs): 사전 검증이 도입됨에 따라 GetIssuesAsync 내부에 혼재되어 있던 존재 여부 검증 블록(repository(owner, name) { id })을 삭제하고 조회 책임만 남김
- [ ] 예외 처리 일원화 및 강제 종료 버그 수정 (Program.cs): 수집 루프 내부에 있던 Environment.Exit(1) 강제 종료 코드를 제거. 형식 오류나 존재하지 않는 저장소는 병렬 작업 진입 전에 앞단에서 걸러내어 안전하게 예외(CommandExitedException)를 던지도록 수정

### 🧪 테스트 방법 (선택 사항)
<!-- 변경 사항이 정상 동작하는지 어떻게 확인했는지 작성해주세요 -->

### 💬 참고 사항 (선택 사항)
<!-- 리뷰 시 참고해야 할 내용이나 전달하고 싶은 사항이 있다면 작성해주세요 -->
