### PR TITLE
선점 키워드 매칭이 댓글의 띄어쓰기 변형을 감지하지 못함

### DIFF
--- a/Services/GitHubService.cs
+++ b/Services/GitHubService.cs
@@ -217,7 +217,16 @@ namespace RepoScore.Services
         }
 
         /// <summary>
-        /// [리팩토링 포인트] 데이터 수집 전 저장소의 형식 및 실제 존재 여부를 GraphQL Alias를 사용해 1회 요청으로 일괄 확인합니다.
+        /// 문자열 내부의 모든 공백 문자(스페이스, 탭, 개행 등)를 완전히 제거하여 정규화합니다.
+        /// </summary>
+        private static string NormalizeWhitespace(string s)
+        {
+            if (string.IsNullOrEmpty(s)) return string.Empty;
+            return Regex.Replace(s, @"\s+", "");
+        }
+
+        /// <summary>
+        /// 데이터 수집 전 저장소의 형식 및 실제 존재 여부를 GraphQL Alias를 사용해 1회 요청으로 일괄 확인합니다.
         /// </summary>
         public static async System.Threading.Tasks.Task<(List<string> Malformed, List<string> NotFound)> ValidateRepositoriesAsync(string[] repos, string token)
         {
@@ -269,7 +278,6 @@ namespace RepoScore.Services
                         for (int i = 0; i < validRepos.Count; i++)
                         {
                             string alias = $"r{i}";
-                            // 부분 실패 시 해당 alias 필드는 응답 json 내에서 null로 떨어집니다.
                             if (!dataElement.TryGetProperty(alias, out var repoElement) || repoElement.ValueKind == JsonValueKind.Null)
                             {
                                 notFound.Add(validRepos[i].Original);
@@ -359,7 +367,6 @@ namespace RepoScore.Services
         /// <exception cref="InvalidOperationException">저장소가 존재하지 않거나 GitHub API 측에서 오류 응답을 반환할 때 발생합니다.</exception>
         public async System.Threading.Tasks.Task<List<IssueRecord>> GetIssuesAsync(DateTimeOffset? since = null)
         {
-            // [리팩토링 포인트] 불필요한 중복 존재 검증 블록인 repository(owner, name) { id } 제거 및 검색 쿼리 단일화
             const string rawGraphQl = @"
             query($searchQuery: String!, $after: String) {
                 search(query: $searchQuery, type: ISSUE, first: 100, after: $after) {
@@ -738,7 +745,8 @@ namespace RepoScore.Services
                                 continue;
                             }
 
-                            if (!_claimKeywords.Any(k => body.Contains(k, StringComparison.OrdinalIgnoreCase)))
+                            var normalizedBody = NormalizeWhitespace(body);
+                            if (!_claimKeywords.Any(k => normalizedBody.Contains(NormalizeWhitespace(k), StringComparison.OrdinalIgnoreCase)))
                             {
                                 continue;
                             }


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #509

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- [ ] 문자열 공백 전역 정규화 메서드 추가 (Services/GitHubService.cs): 문자열 내부에 포함된 모든 형태의 공백(스페이스, 이중 공백, 탭, 개행 등)을 정규식(@"\s+")을 통해 완전히 제거하는 NormalizeWhitespace 헬퍼 메서드 구현
- [ ] 선점 키워드 공백 무시 매칭 적용 (Services/GitHubService.cs): FetchOpenIssuesWithClaimCommentsAsync 메서드 내에서 댓글 본문과 선점 키워드를 판별하기 직전, 양쪽 문자열의 모든 내부 공백을 지운 뒤 비교하도록 수정하여 띄어쓰기 변형(제가하겠습니다, 제가  하겠습니다)에 상관없이 선점 의사를 정확히 감지하도록 버그 수정

### 🧪 테스트 방법 (선택 사항)
<!-- 변경 사항이 정상 동작하는지 어떻게 확인했는지 작성해주세요 -->

### 💬 참고 사항 (선택 사항)
<!-- 리뷰 시 참고해야 할 내용이나 전달하고 싶은 사항이 있다면 작성해주세요 -->
