### PR TITLE
기여 한도 계산 로직 중복 제거

### DIFF
--- a/Data/ReportFormatter.cs
+++ b/Data/ReportFormatter.cs
@@ -69,14 +69,14 @@ namespace RepoScore.Data
 
                 var r = row.Raw;
 
-                int maxAdditionalPr = 3 * Math.Max(r.featBugPrs, 1);
-                int totalDocTypoPr = r.docPrs + r.typoPrs;
-                int rejectedPr = Math.Max(0, totalDocTypoPr - maxAdditionalPr);
+                var limits = ScoreCalculator.CalculateLimits(r.featBugPrs, r.docPrs, r.typoPrs, r.featBugIssues, r.docIssues);
 
-                int validPrCount = r.featBugPrs + Math.Min(totalDocTypoPr, maxAdditionalPr);
-                int maxIssueCount = 4 * validPrCount;
-                int totalIssues = r.featBugIssues + r.docIssues;
-                int rejectedIssue = Math.Max(0, totalIssues - maxIssueCount);
+                int maxAdditionalPr = limits.MaxDocTypoPrCount;
+                int rejectedPr = limits.RejectedPrCount;
+                int maxIssueCount = limits.MaxIssueCount;
+                int rejectedIssue = limits.RejectedIssueCount;
+
+                int totalDocTypoPr = r.docPrs + r.typoPrs;
 
                 if (rejectedPr > 0 || rejectedIssue > 0)
                 {
@@ -86,20 +86,20 @@ namespace RepoScore.Data
 
                     if (rejectedPr > 0)
                     {
-                        int docSuggestionCount = (rejectedPr + 2) / 3;
-                        userRejections.AppendLine($"   [추가 제안] 기능/버그 PR {docSuggestionCount}개 추가 시 문서PR 인정 한도 +{docSuggestionCount * 3}");
+                        int docSuggestionCount = (rejectedPr + (ScoreCalculator.MaxDocTypoPrMultiplier - 1)) / ScoreCalculator.MaxDocTypoPrMultiplier;
+                        userRejections.AppendLine($"   [추가 제안] 기능/버그 PR {docSuggestionCount}개 추가 시 문서PR 인정 한도 +{docSuggestionCount * ScoreCalculator.MaxDocTypoPrMultiplier}");
                     }
 
                     if (rejectedIssue > 0)
                     {
-                        int issueSuggestionCount = (rejectedIssue + 3) / 4;
+                        int issueSuggestionCount = (rejectedIssue + (ScoreCalculator.MaxIssuePerValidPrMultiplier - 1)) / ScoreCalculator.MaxIssuePerValidPrMultiplier;
                         if (totalDocTypoPr < maxAdditionalPr)
                         {
-                            userRejections.AppendLine($"   [추가 제안] 문서 PR {issueSuggestionCount}개 추가 혹은 기능/버그 PR {issueSuggestionCount}개 추가시 이슈 인정한도 +{issueSuggestionCount * 4}");
+                            userRejections.AppendLine($"   [추가 제안] 문서 PR {issueSuggestionCount}개 추가 혹은 기능/버그 PR {issueSuggestionCount}개 추가시 이슈 인정한도 +{issueSuggestionCount * ScoreCalculator.MaxIssuePerValidPrMultiplier}");
                         }
                         else
                         {
-                            userRejections.AppendLine($"   [추가 제안] 기능/버그 PR {issueSuggestionCount}개 추가시 이슈 인정한도 +{issueSuggestionCount * 4}");
+                            userRejections.AppendLine($"   [추가 제안] 기능/버그 PR {issueSuggestionCount}개 추가시 이슈 인정한도 +{issueSuggestionCount * ScoreCalculator.MaxIssuePerValidPrMultiplier}");
                         }
                     }
 

--- a/Data/ScoreCalculator.cs
+++ b/Data/ScoreCalculator.cs
@@ -61,6 +61,12 @@ namespace RepoScore.Data
         /// <summary>
         /// 학생의 기여 내역을 바탕으로 최종 점수를 계산합니다.
         /// </summary>
+        /// <param name="featureBugPrCount">기능/버그 PR 개수 (Merged)</param>
+        /// <param name="docPrCount">문서 PR 개수 (Merged)</param>
+        /// <param name="typoPrCount">오타 PR 개수 (Merged)</param>
+        /// <param name="featureBugIssueCount">기능/버그 이슈 개수 (Open/Resolved)</param>
+        /// <param name="docIssueCount">문서 이슈 개수 (Open/Resolved)</param>
+        /// <returns>최종 산출된 점수</returns>
         public static int CalculateFinalScore(
             int featureBugPrCount,
             int docPrCount,

--- a/Data/ScoreCalculator.cs
+++ b/Data/ScoreCalculator.cs
@@ -1,12 +1,29 @@
+using System;
 
 namespace RepoScore.Data
 {
+    /// <summary>
+    /// 한도 계산 공식의 결과 데이터를 보관하는 구조체 클래스입니다.
+    /// </summary>
+    public class ContributionLimitResult
+    {
+        public int MaxDocTypoPrCount { get; set; }
+        public int ValidPrCount { get; set; }
+        public int MaxIssueCount { get; set; }
+        public int ValidIssueCount { get; set; }
+        public int RejectedPrCount { get; set; }
+        public int RejectedIssueCount { get; set; }
+    }
+
     /// <summary>
     /// 오픈소스 기여 점수를 계산하는 클래스입니다.
     /// PR 및 이슈 개수 비율에 따른 유효 개수 제한(Validity Limits)을 적용하여 최종 점수를 산출합니다.
     /// </summary>
     public static class ScoreCalculator
     {
+        public const int MaxDocTypoPrMultiplier = 3;
+        public const int MaxIssuePerValidPrMultiplier = 4;
+
         private const int s_scorePrFeatureBug = 3;
         private const int s_scorePrDoc = 2;
         private const int s_scorePrTypo = 1;
@@ -14,15 +31,36 @@ namespace RepoScore.Data
         private const int s_scoreIssueFeatureBug = 2;
         private const int s_scoreIssueDoc = 1;
 
+        public static ContributionLimitResult CalculateLimits(
+            int featureBugPrCount,
+            int docPrCount,
+            int typoPrCount,
+            int featureBugIssueCount,
+            int docIssueCount)
+        {
+            int maxDocTypoPrCount = MaxDocTypoPrMultiplier * Math.Max(featureBugPrCount, 1);
+            int validPrCount = featureBugPrCount + Math.Min(docPrCount + typoPrCount, maxDocTypoPrCount);
+            int maxIssueCount = MaxIssuePerValidPrMultiplier * validPrCount;
+            int validIssueCount = Math.Min(featureBugIssueCount + docIssueCount, maxIssueCount);
+
+            // ReportFormatter에서 사용할 문서/오타 PR 및 이슈의 초과분(Rejected) 계산
+            int rejectedPrCount = Math.Max(0, (docPrCount + typoPrCount) - maxDocTypoPrCount);
+            int rejectedIssueCount = Math.Max(0, (featureBugIssueCount + docIssueCount) - maxIssueCount);
+
+            return new ContributionLimitResult
+            {
+                MaxDocTypoPrCount = maxDocTypoPrCount,
+                ValidPrCount = validPrCount,
+                MaxIssueCount = maxIssueCount,
+                ValidIssueCount = validIssueCount,
+                RejectedPrCount = rejectedPrCount,
+                RejectedIssueCount = rejectedIssueCount
+            };
+        }
+
         /// <summary>
         /// 학생의 기여 내역을 바탕으로 최종 점수를 계산합니다.
         /// </summary>
-        /// <param name="featureBugPrCount">기능/버그 PR 개수 (Merged)</param>
-        /// <param name="docPrCount">문서 PR 개수 (Merged)</param>
-        /// <param name="typoPrCount">오타 PR 개수 (Merged)</param>
-        /// <param name="featureBugIssueCount">기능/버그 이슈 개수 (Open/Resolved)</param>
-        /// <param name="docIssueCount">문서 이슈 개수 (Open/Resolved)</param>
-        /// <returns>최종 산출된 점수</returns>
         public static int CalculateFinalScore(
             int featureBugPrCount,
             int docPrCount,
@@ -30,12 +68,10 @@ namespace RepoScore.Data
             int featureBugIssueCount,
             int docIssueCount)
         {
-            // 1단계: 유효 PR 개수 제한 산정 (P_valid)
-            int maxAdditionalPrCount = 3 * Math.Max(featureBugPrCount, 1);
-            int validPrCount = featureBugPrCount + Math.Min(docPrCount + typoPrCount, maxAdditionalPrCount);
-
-            // 2단계: 유효 이슈 개수 제한 산정 (I_valid)
-            int validIssueCount = Math.Min(featureBugIssueCount + docIssueCount, 4 * validPrCount);
+            // 1단계 & 2단계: 공용 한도 계산 메서드 호출로 대체
+            var limits = CalculateLimits(featureBugPrCount, docPrCount, typoPrCount, featureBugIssueCount, docIssueCount);
+            int validPrCount = limits.ValidPrCount;
+            int validIssueCount = limits.ValidIssueCount;
 
             // 3단계: PR 최적화 계산 (배점이 높은 기능/버그 -> 문서 -> 오타 순으로 채움)
             int optimizedFeatureBugPrCount = Math.Min(featureBugPrCount, validPrCount);


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #513

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- [ ] 공용 한도 계산 메서드 및 결과 구조체 도입 (Data/ScoreCalculator.cs): 두 파일에 파편화되어 중복되던 기여 한도 공식(유효 PR 및 이슈 제한, 초과분 산출)을 단일화하기 위해 CalculateLimits 메서드와 ContributionLimitResult 클래스를 새로 구현. 실제 점수 계산 로직(CalculateFinalScore)이 이 공용 메서드를 바라보도록 리팩토링 진행
- [ ] 한도 배수 규칙 상수화 (Data/ScoreCalculator.cs): 기존 코드에 매직 넘버로 하드코딩되어 있던 문서/오타 PR 한도 배수(3)와 이슈 한도 배수(4)를 의미가 명확한 MaxDocTypoPrMultiplier 및 MaxIssuePerValidPrMultiplier 상수로 분리하여 외부 파일에서도 참조할 수 있도록 public 선언
- [ ] 중복 하드코딩 로직 제거 및 연동 (Data/ReportFormatter.cs): 리포트 출력 단에서 독자적으로 연산하던 한도 및 초과분 계산 코드를 전면 삭제하고 ScoreCalculator.CalculateLimits 호출 방식으로 대체. 안내 문구 생성 로직 내 나눗셈 및 곱셈 필터링 영역까지 모두 공용 상수를 적용하여 연산 정합성 확보

### 🧪 테스트 방법 (선택 사항)
<!-- 변경 사항이 정상 동작하는지 어떻게 확인했는지 작성해주세요 -->

### 💬 참고 사항 (선택 사항)
<!-- 리뷰 시 참고해야 할 내용이나 전달하고 싶은 사항이 있다면 작성해주세요 -->
