### PR TITLE
#517 --claims 출력에 저장소 식별 머리말 추가

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -146,7 +146,7 @@ await CoconaApp.RunAsync(async (
                         cachedOpenIssues, cachedOpenPrs, claimsSince);
 
                     var report = ReportFormatter.BuildClaimsReport(claimsData, (ClaimsMode)claims);
-                    Console.Write(report);
+                    Console.Write($"=== {repo} 이슈 선점 현황 ===\n{report}\n");
 
                     CacheManager.SaveClaimsCache(cachePath, cache, updatedOpenIssues, updatedOpenPrs);
                     Log.Information("[{Repo}] Claims 캐시 갱신 완료: {CachePath}", repo, cachePath);


### PR DESCRIPTION
### ISSUE_ID
Closes #517

### 변경사항
- [x] `Program.cs`: `--claims` 출력 시 각 저장소 리포트 앞에 `=== {repo} 이슈 선점 현황 ===` 머리말 추가

**변경 전**
```csharp
var report = ReportFormatter.BuildClaimsReport(claimsData, (ClaimsMode)claims);
Console.Write(report);
```

**변경 후**
```csharp
var report = ReportFormatter.BuildClaimsReport(claimsData, (ClaimsMode)claims);
Console.Write($"=== {repo} 이슈 선점 현황 ===\n{report}\n");
```

### 💬 참고 사항
- 머리말과 본문을 단일 `Console.Write` 호출로 묶어 출력하므로, 멀티 저장소 병렬 실행 시에도 다른 저장소 출력이 머리말 사이에 끼어들지 않음
- `BuildTextReport`의 `=== {repo} ... ===` 스타일과 일관성 유지
- 단일/멀티 저장소 실제 실행으로 동작 확인 완료