### PR TITLE
[DOC] --claims 단독 사용 예시 삭제 및 수정(README, cli-options-guide)

### DIFF
--- a/README-template.md.j2
+++ b/README-template.md.j2
@@ -29,7 +29,6 @@ dotnet run -- oss2026hnu/reposcore-cs --token YOUR_GITHUB_TOKEN
 dotnet run -- oss2026hnu/reposcore-cs oss2026hnu/reposcore-ts --token YOUR_GITHUB_TOKEN
 
 # 최근 이슈 선점 현황 조회 예시 (Codespaces 환경에서는 토큰 생략 가능)
-dotnet run -- oss2026hnu/reposcore-cs --claims --token YOUR_GITHUB_TOKEN      # 이슈별 (기본값)
 dotnet run -- oss2026hnu/reposcore-cs --claims issue --token YOUR_GITHUB_TOKEN # 이슈별 (명시)
 dotnet run -- oss2026hnu/reposcore-cs --claims user --token YOUR_GITHUB_TOKEN  # 유저별
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ dotnet run -- oss2026hnu/reposcore-cs --token YOUR_GITHUB_TOKEN
 dotnet run -- oss2026hnu/reposcore-cs oss2026hnu/reposcore-ts --token YOUR_GITHUB_TOKEN
 
 # 최근 이슈 선점 현황 조회 예시 (Codespaces 환경에서는 토큰 생략 가능)
-dotnet run -- oss2026hnu/reposcore-cs --claims --token YOUR_GITHUB_TOKEN      # 이슈별 (기본값)
 dotnet run -- oss2026hnu/reposcore-cs --claims issue --token YOUR_GITHUB_TOKEN # 이슈별 (명시)
 dotnet run -- oss2026hnu/reposcore-cs --claims user --token YOUR_GITHUB_TOKEN  # 유저별
 

--- a/docs/cli-options-guide.md
+++ b/docs/cli-options-guide.md
@@ -284,7 +284,7 @@ dotnet run -- oss2026hnu/reposcore-cs -t ghp_xxxxx --sort-by score --sort-order 
 
 ```bash
 # 이슈별 조회 (기본)
-dotnet run -- oss2026hnu/reposcore-cs --claims -t ghp_xxxxx
+dotnet run -- oss2026hnu/reposcore-cs --claims issue -t ghp_xxxxx
 
 # 유저별 조회
 dotnet run -- oss2026hnu/reposcore-cs --claims user -t ghp_xxxxx


### PR DESCRIPTION
### ISSUE_ID
Closes https://github.com/oss2026hnu/reposcore-cs/issues/516

### 변경사항
- [x] README-template.md.j2의 잘못된 --claims 단독 사용 예시 제거
- [x] docs/cli-options-guide.md의 이슈 선점 현황 조회 예시를 실제 동작에 맞게 수정

### 🧪 테스트 방법 (선택 사항)
- make 실행 후 재생성된 README.md에 변경 사항이 정상 반영되었는지 확인

### 💬 참고 사항 (선택 사항)
- README.md는 직접 수정하지 않고 README-template.md.j2를 수정한 뒤 make를 실행하여 자동 생성하였습니다.
- docs/cli-options-guide.md는 자동 생성 대상이 아니므로 해당 파일을 직접 수정하였습니다.