### PR TITLE
이슈 닫힌 사유 처리 개선: 중복 및 계획되지 않은 이슈를 필터링

### DIFF
--- a/Services/GitHubService.cs
+++ b/Services/GitHubService.cs
@@ -467,13 +467,17 @@ namespace RepoScore.Services
                             }
                         }
 
+                        var closedReason = ParseIssueClosedStateReason(node);
+                        if (closedReason == IssueClosedStateReason.Duplicate || closedReason == IssueClosedStateReason.NotPlanned)
+                            continue;
+
                         issueRecords.Add(new IssueRecord
                         {
                             Number = node.TryGetProperty("number", out var numEl) ? numEl.GetInt32() : 0,
                             Title = node.TryGetProperty("title", out var titEl) ? titEl.GetString() ?? "" : "",
                             Url = node.TryGetProperty("url", out var urlEl) ? urlEl.GetString() ?? "" : "",
                             AuthorLogin = authorLogin,
-                            ClosedReason = ParseIssueClosedStateReason(node),
+                            ClosedReason = closedReason,
                             Labels = labelNames.Select(ParseGitHubLabel).Where(l => l != GitHubIssuePrLabel.None).ToList(),
                             UpdatedAt = updatedAt
                         });


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #522 

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- [ ] `GitHubService.cs`의 `GetIssuesAsync()` 메서드에서 `duplicate` 및 `not planned` 사유로 닫힌 이슈를 파싱 단계에서 명시적으로 제외하도록 로직 추가
- [ ] `IssueRecord` 객체 초기화 과정에서 `ClosedReason` 속성이 중복으로 할당되던 컴파일/문법 오류 제거
### 🧪 테스트 방법 (선택 사항)
<!-- 변경 사항이 정상 동작하는지 어떻게 확인했는지 작성해주세요 -->
dotnet run -- oss2026hnu/reposcore-cs oss2026hnu/reposcore-ts oss2026hnu/reposcore-py

### 💬 참고 사항 (선택 사항)
<!-- 리뷰 시 참고해야 할 내용이나 전달하고 싶은 사항이 있다면 작성해주세요 -->
