### PR TITLE
Program.cs 내부의 리포트 출력 및 데이터 병합 로직 분리

### DIFF
--- a/Data/CacheManager.cs
+++ b/Data/CacheManager.cs
@@ -173,5 +173,38 @@ namespace RepoScore.Data
                 .OrderBy(x => x)
                 .SequenceEqual(currentKeywords.OrderBy(x => x));
         }
+
+        /// <summary>
+        /// 다수의 저장소에서 수집된 유저별 기록을 중복을 제거하여 하나로 병합합니다.
+        /// </summary>
+        public static void MergeUserRecords<T>(
+            Dictionary<string, List<T>> target,
+            Dictionary<string, List<T>> source)
+        {
+            foreach (var (user, items) in source)
+            {
+                if (!target.TryGetValue(user, out var targetList))
+                {
+                    targetList = new List<T>();
+                    target[user] = targetList;
+                }
+
+                foreach (var item in items)
+                {
+                    bool isDuplicate = item switch
+                    {
+                        IssueRecord issue => string.IsNullOrEmpty(issue.Url)
+                            ? targetList.Any(t => t is IssueRecord i && string.IsNullOrEmpty(i.Url) && i.Number == issue.Number)
+                            : targetList.Any(t => t is IssueRecord i && i.Url == issue.Url),
+                        PRRecord pr => string.IsNullOrEmpty(pr.Url)
+                            ? targetList.Any(t => t is PRRecord p && string.IsNullOrEmpty(p.Url) && p.Number == pr.Number)
+                            : targetList.Any(t => t is PRRecord p && p.Url == pr.Url),
+                        _ => false
+                    };
+
+                    if (!isDuplicate) targetList.Add(item);
+                }
+            }
+        }
     }
 }

--- a/Data/ReportFormatter.cs
+++ b/Data/ReportFormatter.cs
@@ -2,6 +2,7 @@ using System.Text;
 using RepoScore.Services;
 using System.Text.Json;
 using Spectre.Console;
+using Serilog;
 
 namespace RepoScore.Data
 {
@@ -309,6 +310,46 @@ namespace RepoScore.Data
         {
             if (remaining <= TimeSpan.Zero) return "   기한 초과";
             return $"   남은 시간: {(int)remaining.TotalHours:D2}:{remaining.Minutes:D2}:{remaining.Seconds:D2}";
+        }
+
+        /// <summary>
+        /// CSV, TXT, HTML 서식에 맞춰 리포트 파일을 물리 디렉토리에 내보내는 공통 메서드입니다.
+        /// </summary>
+        public static void ExportReports(
+            string label,
+            List<(string Id, int docIssues, int featBugIssues, int typoPrs, int docPrs, int featBugPrs, int Score)> reportData,
+            HashSet<OutputFormat> activeFormats,
+            string outputDir)
+        {
+            if (!Directory.Exists(outputDir)) Directory.CreateDirectory(outputDir);
+
+            if (activeFormats.Contains(OutputFormat.Csv))
+            {
+                var csv = new StringBuilder();
+                csv.AppendLine("아이디, 문서이슈, 버그/기능이슈, 오타PR, 문서PR, 버그/기능PR, 총점");
+                foreach (var r in reportData)
+                    csv.AppendLine($"{r.Id}, {r.docIssues}, {r.featBugIssues}, {r.typoPrs}, {r.docPrs}, {r.featBugPrs}, {r.Score}");
+
+                string csvPath = Path.Combine(outputDir, "results.csv");
+                File.WriteAllText(csvPath, csv.ToString(), Encoding.UTF8);
+                Log.Information("[{Label}] 데이터(CSV) 저장 완료: {CsvPath}", label, csvPath);
+            }
+
+            if (activeFormats.Contains(OutputFormat.Txt))
+            {
+                string txtPath = Path.Combine(outputDir, "results.txt");
+                string txtContent = BuildTextReport(label, reportData);
+                File.WriteAllText(txtPath, txtContent, Encoding.UTF8);
+                Log.Information("[{Label}] 가독성 리포트(TXT) 저장 완료: {TxtPath}", label, txtPath);
+            }
+
+            if (activeFormats.Contains(OutputFormat.Html))
+            {
+                string htmlPath = Path.Combine(outputDir, "results.html");
+                string htmlContent = BuildHtmlReport(label, reportData);
+                File.WriteAllText(htmlPath, htmlContent, Encoding.UTF8);
+                Log.Information("[{Label}] HTML 리포트 저장 완료: {HtmlPath}", label, htmlPath);
+            }
         }
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -251,7 +251,7 @@ await CoconaApp.RunAsync(async (
                 reportData = ReportSorter.SortReportData(reportData, sortBy, sortOrder);
 
                 // ── 개별 저장소 리포트 출력 ──
-                ExportReports(repo, reportData, activeFormats, repoOutput);
+                ReportFormatter.ExportReports(repo, reportData, activeFormats, repoOutput);
 
                 if (repos.Length > 1)
                 {
@@ -286,8 +286,8 @@ await CoconaApp.RunAsync(async (
 
             foreach (var (_, (userIssues, userPrs)) in repoResults)
             {
-                MergeUserRecords(totalUserIssues, userIssues);
-                MergeUserRecords(totalUserPullRequests, userPrs);
+                CacheManager.MergeUserRecords(totalUserIssues, userIssues);
+                CacheManager.MergeUserRecords(totalUserPullRequests, userPrs);
             }
 
             var totalReportData = new List<(string Id, int docIssues, int featBugIssues, int typoPrs, int docPrs, int featBugPrs, int Score)>();
@@ -312,7 +312,7 @@ await CoconaApp.RunAsync(async (
             totalReportData = ReportSorter.SortReportData(totalReportData, sortBy, sortOrder);
 
             string totalLabel = string.Join(" + ", repos);
-            ExportReports(totalLabel, totalReportData, activeFormats, output);
+            ReportFormatter.ExportReports(totalLabel, totalReportData, activeFormats, output);
         }
         catch (Exception ex)
         {
@@ -328,81 +328,3 @@ await CoconaApp.RunAsync(async (
         throw new CommandExitedException(1);
     }
 });
-
-
-/// <summary>
-/// CSV, TXT, HTML 서식에 맞춰 리포트 파일을 물리 디렉토리에 내보내는 공통 메서드
-/// </summary>
-static void ExportReports(
-    string label,
-    List<(string Id, int docIssues, int featBugIssues, int typoPrs, int docPrs, int featBugPrs, int Score)> reportData,
-    HashSet<OutputFormat> activeFormats,
-    string outputDir)
-{
-    if (!Directory.Exists(outputDir)) Directory.CreateDirectory(outputDir);
-
-    if (activeFormats.Contains(OutputFormat.Csv))
-    {
-        var csv = new StringBuilder();
-        csv.AppendLine("아이디, 문서이슈, 버그/기능이슈, 오타PR, 문서PR, 버그/기능PR, 총점");
-        foreach (var r in reportData)
-            csv.AppendLine($"{r.Id}, {r.docIssues}, {r.featBugIssues}, {r.typoPrs}, {r.docPrs}, {r.featBugPrs}, {r.Score}");
-
-        string csvPath = Path.Combine(outputDir, "results.csv");
-        File.WriteAllText(csvPath, csv.ToString(), Encoding.UTF8);
-        Log.Information("[{Label}] 데이터(CSV) 저장 완료: {CsvPath}", label, csvPath);
-    }
-
-    if (activeFormats.Contains(OutputFormat.Txt))
-    {
-        string txtPath = Path.Combine(outputDir, "results.txt");
-        string txtContent = ReportFormatter.BuildTextReport(label, reportData);
-        File.WriteAllText(txtPath, txtContent, Encoding.UTF8);
-        Log.Information("[{Label}] 가독성 리포트(TXT) 저장 완료: {TxtPath}", label, txtPath);
-    }
-
-    if (activeFormats.Contains(OutputFormat.Html))
-    {
-        string htmlPath = Path.Combine(outputDir, "results.html");
-        string htmlContent = ReportFormatter.BuildHtmlReport(label, reportData);
-        File.WriteAllText(htmlPath, htmlContent, Encoding.UTF8);
-        Log.Information("[{Label}] HTML 리포트 저장 완료: {HtmlPath}", label, htmlPath);
-    }
-}
-
-static void MergeUserRecords<T>(
-    Dictionary<string, List<T>> target,
-    Dictionary<string, List<T>> source)
-{
-    foreach (var (user, items) in source)
-    {
-        if (!target.TryGetValue(user, out var targetList))
-        {
-            targetList = new List<T>();
-            target[user] = targetList;
-        }
-
-        foreach (var item in items)
-        {
-            bool isDuplicate = false;
-
-            if (item is IssueRecord issue)
-            {
-                isDuplicate = string.IsNullOrEmpty(issue.Url)
-                    ? targetList.Any(t => t is IssueRecord i && string.IsNullOrEmpty(i.Url) && i.Number == issue.Number)
-                    : targetList.Any(t => t is IssueRecord i && i.Url == issue.Url);
-            }
-            else if (item is PRRecord pr)
-            {
-                isDuplicate = string.IsNullOrEmpty(pr.Url)
-                    ? targetList.Any(t => t is PRRecord p && string.IsNullOrEmpty(p.Url) && p.Number == pr.Number)
-                    : targetList.Any(t => t is PRRecord p && p.Url == pr.Url);
-            }
-
-            if (!isDuplicate)
-            {
-                targetList.Add(item);
-            }
-        }
-    }
-}


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #525 

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- [ ] `Program.cs` 내부에 있던 리포트 파일 출력 로직(`ExportReports`)을 문자열 가공을 전담하는 `Data/ReportFormatter.cs`로 이동 및 분리
- [ ] `Program.cs` 내부에 있던 유저 통계 병합 로직(`MergeUserRecords`)을 데이터 딕셔너리를 관리하는 `Data/CacheManager.cs`로 이동 및 분리
- [ ] `Program.cs` 진입점에 혼재되어 있던 구체적인 세부 구현 코드를 제거하여 단일 책임 원칙(SRP) 준수 및 가독성 대폭 향상

### 🧪 테스트 방법 (선택 사항)
dotnet run -- oss2026hnu/reposcore-cs oss2026hnu/reposcore-ts oss2026hnu/reposcore-py --token {토큰}

위 명령어를 실행하여 정상 동작 여부 확인

### 💬 참고 사항 (선택 사항)

