### PR TITLE
GitHubService.cs 하드코딩된 매직 넘버 상수화

### DIFF
--- a/Services/GitHubService.cs
+++ b/Services/GitHubService.cs
@@ -196,6 +196,9 @@ namespace RepoScore.Services
         private static readonly string[] s_defaultClaimKeywords = ["제가 하겠습니다", "진행하겠습니다", "할게요", "I'll take this"];
         private readonly string[] _claimKeywords;
 
+        public const double DefaultClaimExpirationHours = 48.0;
+        public const double DocumentClaimExpirationHours = 24.0;
+
         /// <summary>
         /// 지정된 저장소 정보 및 인증 토큰을 사용하여 <see cref="GitHubService"/> 클래스의 새 인스턴스를 초기화합니다.
         /// </summary>
@@ -498,7 +501,7 @@ namespace RepoScore.Services
                 DateTimeOffset? since = null)
         {
             var now = DateTimeOffset.UtcNow;
-            bool isFullRefresh = since == null || (now - since.Value).TotalHours > 48;
+            bool isFullRefresh = since == null || (now - since.Value).TotalHours > DefaultClaimExpirationHours;
 
             var freshOpenPrs = await GetOpenPullRequestsWithLinkedIssuesAsync(isFullRefresh ? null : since);
 
@@ -554,10 +557,10 @@ namespace RepoScore.Services
 
                 foreach (var comment in comments)
                 {
-                    if ((now - comment.CreatedAt).TotalHours > 48) continue;
+                    if ((now - comment.CreatedAt).TotalHours > DefaultClaimExpirationHours) continue;
 
                     var login = comment.AuthorLogin;
-                    var deadlineHours = IsDocumentTask(issueLabels) ? 24.0 : 48.0;
+                    var deadlineHours = IsDocumentTask(issueLabels) ? DocumentClaimExpirationHours : DefaultClaimExpirationHours;
                     var remaining = comment.CreatedAt.AddHours(deadlineHours) - now;
 
                     var linkedPrs = updatedOpenPrs
@@ -740,7 +743,7 @@ namespace RepoScore.Services
                                 ? DateTimeOffset.Parse(createdAtElement.GetString()!)
                                 : DateTimeOffset.MinValue;
 
-                            if ((now - createdAt).TotalHours > 48)
+                            if ((now - createdAt).TotalHours > DefaultClaimExpirationHours)
                             {
                                 continue;
                             }


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #527 

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- [ ] GitHubService.cs 내부의 선점 만료 시간(48, 24)을 명시적인 상수(DefaultClaimExpirationHours, DocumentClaimExpirationHours)로 추출 및 선언
- [ ] 변경 사항 2
- [ ] 변경 사항 3

### 🧪 테스트 방법 (선택 사항)
dotnet run -- oss2026hnu/reposcore-cs oss2026hnu/reposcore-ts oss2026hnu/reposcore-py --token {토큰} --claims 

위 명령어를 실행하여 정상동작 확인

### 💬 참고 사항 (선택 사항)
<!-- 리뷰 시 참고해야 할 내용이나 전달하고 싶은 사항이 있다면 작성해주세요 -->
